### PR TITLE
VDP cmd engine: fix LMMM and YMMM command timing (issue #2057)

### DIFF
--- a/doc/internal/vdp-cmd-timing-issue2057-capture-check.py
+++ b/doc/internal/vdp-cmd-timing-issue2057-capture-check.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import re, sys, glob
+
+def parse(fn):
+    """Return list of (abs_time, R/W, addr) for command-engine accesses."""
+    events = []
+    for line in open(fn, encoding='utf-8', errors='replace'):
+        m = re.match(r'\s*(\d+):(.*)$', line)
+        if not m: continue
+        cyc = int(m.group(1)); rest = m.group(2)
+        # columns are successive lines; find all access tokens with their column
+        for cm in re.finditer(r'([RW])\.(\w) (0x[0-9a-f]+)', rest):
+            col = cm.start() // 13   # column width heuristic
+            if cm.group(2) == 'e':
+                events.append((col, cyc, cm.group(1), int(cm.group(3), 16)))
+    # absolute time = col*1368 + cyc
+    ev = sorted((c*1368 + t, rw, a) for c, t, rw, a in events)
+    return ev
+
+for fn in sorted(glob.glob('8.final-analysis/*YMMM*.txt')):
+    ev = parse(fn)
+    if not ev: print(fn, 'no engine events'); continue
+    print(f'\n=== {fn}: {len(ev)} engine accesses ===')
+    rw_gaps, wr_gaps, trans = {}, {}, []
+    for i in range(1, len(ev)):
+        t0, rw0, a0 = ev[i-1]; t1, rw1, a1 = ev[i]
+        gap = t1 - t0
+        if rw0 == 'R' and rw1 == 'W':
+            rw_gaps[gap] = rw_gaps.get(gap, 0) + 1
+        elif rw0 == 'W' and rw1 == 'R':
+            wr_gaps[gap] = wr_gaps.get(gap, 0) + 1
+            # line transition in the rect = read addr not prev read addr+1
+            if i >= 2:
+                prev_r = ev[i-2][2] if ev[i-2][1] == 'R' else None
+                if prev_r is not None and a1 != prev_r + 1:
+                    trans.append((gap, prev_r, a1))
+    print('R->W gaps:', dict(sorted(rw_gaps.items())))
+    print('W->R gaps:', dict(sorted(wr_gaps.items())))
+    print('W->R gaps at rect line transitions (addr jump):',
+          trans if trans else 'none captured')

--- a/doc/internal/vdp-cmd-timing-issue2057-sim.py
+++ b/doc/internal/vdp-cmd-timing-issue2057-sim.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Simulate openMSX's VDP command engine slot model (VDPCmdEngine.cc +
+VDPAccessSlots.cc) and compare with vdpcmdx measurements (issue #2057).
+
+Model: each VRAM access happens on an access slot. After an access at time t,
+the next access happens at the first slot >= t + delta (delta from Grauw's
+measurements). Line length = 1368 VDP ticks.
+"""
+import bisect
+
+LINE = 1368
+
+SLOTS_SPRITES_ON = [28, 92, 162, 170, 188, 220, 252, 316, 348, 380,
+                    444, 476, 508, 572, 604, 636, 700, 732, 764, 828,
+                    860, 892, 956, 988, 1020, 1084, 1116, 1148, 1212, 1264,
+                    1330]
+
+SLOTS_SPRITES_OFF = [6, 14, 22, 30, 38, 46, 54, 62, 70, 78,
+                     86, 94, 102, 110, 118, 162, 170, 182, 188, 214,
+                     220, 246, 252, 278, 310, 316, 342, 348, 374, 380,
+                     406, 438, 444, 470, 476, 502, 508, 534, 566, 572,
+                     598, 604, 630, 636, 662, 694, 700, 726, 732, 758,
+                     764, 790, 822, 828, 854, 860, 886, 892, 918, 950,
+                     956, 982, 988, 1014, 1020, 1046, 1078, 1084, 1110, 1116,
+                     1142, 1148, 1174, 1206, 1212, 1266, 1274, 1282, 1290, 1298,
+                     1306, 1314, 1322, 1332, 1342, 1350, 1358, 1366]
+
+SLOTS_SCREEN_OFF = [0, 8, 16, 24, 32, 40, 48, 56, 64, 72,
+                    80, 88, 96, 104, 112, 120, 164, 172, 180, 188,
+                    196, 204, 212, 220, 228, 236, 244, 252, 260, 268,
+                    276, 292, 300, 308, 316, 324, 332, 340, 348, 356,
+                    364, 372, 380, 388, 396, 404, 420, 428, 436, 444,
+                    452, 460, 468, 476, 484, 492, 500, 508, 516, 524,
+                    532, 548, 556, 564, 572, 580, 588, 596, 604, 612,
+                    620, 628, 636, 644, 652, 660, 676, 684, 692, 700,
+                    708, 716, 724, 732, 740, 748, 756, 764, 772, 780,
+                    788, 804, 812, 820, 828, 836, 844, 852, 860, 868,
+                    876, 884, 892, 900, 908, 916, 932, 940, 948, 956,
+                    964, 972, 980, 988, 996, 1004, 1012, 1020, 1028, 1036,
+                    1044, 1060, 1068, 1076, 1084, 1092, 1100, 1108, 1116, 1124,
+                    1132, 1140, 1148, 1156, 1164, 1172, 1188, 1196, 1204, 1212,
+                    1220, 1228, 1268, 1276, 1284, 1292, 1300, 1308, 1316, 1324,
+                    1334, 1344, 1352, 1360]
+
+def next_slot(slots, t, delta):
+    """First slot at time >= t + delta (openMSX greedy model)."""
+    t2 = t + delta
+    line, pos = divmod(t2, LINE)
+    i = bisect.bisect_left(slots, pos)
+    if i == len(slots):
+        return (line + 1) * LINE + slots[0]
+    return line * LINE + slots[i]
+
+# Command access patterns: list of deltas *after* each access of one pixel.
+# The last delta gets 'wrap_extra' added at end-of-row (every nx pixels).
+# LMMM: srcRead -32-> dstRead -24-> write -64-> (wrap +64)
+COMMANDS = {
+    'HMMM': dict(deltas=[24, 64],     wrap_extra=64),
+    'LMMM': dict(deltas=[32, 24, 64], wrap_extra=64),
+    'YMMM': dict(deltas=[24, 40],     wrap_extra=0),
+    'HMMV': dict(deltas=[48],         wrap_extra=56),
+    'LMMV': dict(deltas=[24, 72],     wrap_extra=64),
+}
+
+def simulate(slots, cmd, nx, window, start=0, next_slot_fn=next_slot):
+    """Count pixels whose *write* completes before 'window' ticks."""
+    spec = COMMANDS[cmd]
+    deltas, wrap_extra = spec['deltas'], spec['wrap_extra']
+    t = next_slot_fn(slots, start, 0)   # startXxxx: nextAccessSlot(time)
+    count = 0
+    col = 0
+    while True:
+        # all accesses of one pixel; write is the last access
+        for j, d in enumerate(deltas):
+            if t >= window:
+                return count
+            if j == len(deltas) - 1:
+                count += 1          # write happened at time t
+                col += 1
+                dd = d + (wrap_extra if col == nx else 0)
+                if col == nx:
+                    col = 0
+                t = next_slot_fn(slots, t, dd)
+            else:
+                t = next_slot_fn(slots, t, d)
+
+TABLES = {'NORMAL': SLOTS_SPRITES_ON, 'NO_SPR': SLOTS_SPRITES_OFF,
+          'NO_SCR': SLOTS_SCREEN_OFF}
+
+# vdpcmdx geometry (screen 8): landscape 256x40 @x=0, portrait 40x256 @x=216
+# YMMM copies DX..right edge: landscape 256 wide, portrait 40 wide.
+GEOM = {'land': 256, 'port': 40}
+
+ACTIVE_WINDOW = 192 * LINE
+VBLANK_WINDOW_PAL = (313 - 192) * LINE
+
+# Measured values (PAL): (openMSX 21 'THIS' from our run, real HW 'REAL')
+MEASURED_ACTIVE = {
+    # cmd, orient: (openMSX, real)
+    ('HMMM', 'land'): (1915, 1915), ('HMMM', 'port'): (1915, 1916),
+    ('LMMM', 'land'): (1717, 1339), ('LMMM', 'port'): (1699, 1332),
+    ('YMMM', 'land'): (2111, 2111), ('YMMM', 'port'): (2111, 2095),
+    ('HMMV', 'land'): (4003, 4005), ('HMMV', 'port'): (3920, 3922),
+    ('LMMV', 'land'): (1907, 1908), ('LMMV', 'port'): (1868, 1869),
+}
+MEASURED_ACTIVE_NOSPR = {
+    ('HMMM', 'land'): (2668, 2673), ('HMMM', 'port'): (2636, 2659),
+    ('LMMM', 'land'): (1970, 1971), ('LMMM', 'port'): (1954, 1955),
+    ('YMMM', 'land'): (2870, 3797), ('YMMM', 'port'): (2871, 3689),
+    ('HMMV', 'land'): (4194, 4195), ('HMMV', 'port'): (4122, 4120),
+    ('LMMV', 'land'): (2104, 2106), ('LMMV', 'port'): (2104, 2106),
+}
+MEASURED_ACTIVE_NOSCR = {
+    ('HMMM', 'land'): (2853, 2854), ('HMMM', 'port'): (2795, 2796),
+    ('LMMM', 'land'): (2003, 2004), ('LMMM', 'port'): (1992, 1993),
+    ('YMMM', 'land'): (4009, 3996), ('YMMM', 'port'): (4012, 3914),
+    ('HMMV', 'land'): (5311, 5313), ('HMMV', 'port'): (5093, 5094),
+    ('LMMV', 'land'): (2666, 2668), ('LMMV', 'port'): (2627, 2627),
+}
+
+def report(title, table, measured, start=0, next_slot_fn=next_slot):
+    print(f'--- {title} (start offset {start}) ---')
+    print(f"{'cmd':6} {'or':4} {'sim':>6} {'openMSX':>8} {'real':>6}")
+    for (cmd, orient), (omsx, real) in measured.items():
+        nx = GEOM[orient]
+        sim = simulate(table, cmd, nx, ACTIVE_WINDOW, start, next_slot_fn)
+        print(f'{cmd:6} {orient:4} {sim:6d} {omsx:8d} {real:6d}')
+    print()
+
+if __name__ == '__main__':
+    for start in (0, 300):
+        report('ACTIVE NORMAL (sprites on, 31 slots)', SLOTS_SPRITES_ON,
+               MEASURED_ACTIVE, start)
+    report('ACTIVE NO_SPR (sprites off, 88 slots)', SLOTS_SPRITES_OFF,
+           MEASURED_ACTIVE_NOSPR, 300)
+    report('ACTIVE NO_SCR (screen off, 154 slots)', SLOTS_SCREEN_OFF,
+           MEASURED_ACTIVE_NOSCR, 300)
+
+# ---------------------------------------------------------------------------
+# Hypothesis testing: rule variants for LMMM
+# ---------------------------------------------------------------------------
+def next_slot_skip(slots, t, delta, skip):
+    """First slot >= t+delta AND at least 'skip+1' slot positions after t."""
+    t2 = t + delta
+    line, pos = divmod(t2, LINE)
+    i = bisect.bisect_left(slots, pos)
+    # index of the slot the previous access used (t is always on a slot)
+    tline, tpos = divmod(t, LINE)
+    ti = bisect.bisect_left(slots, tpos)
+    min_index_abs = (tline * len(slots)) + ti + 1 + skip
+    cand_abs = line * len(slots) + (i if i < len(slots) else len(slots))
+    idx = max(cand_abs, min_index_abs)
+    l2, i2 = divmod(idx, len(slots))
+    return l2 * LINE + slots[i2]
+
+def simulate_lmmm_variant(slots, nx, window, start, variant):
+    """LMMM with a modified rule for the src-read -> dst-read gap."""
+    t = next_slot(slots, start, 0)
+    count = 0
+    col = 0
+    while True:
+        # t = src read time
+        if variant == 'base':
+            t = next_slot(slots, t, 32)          # dst read
+        elif variant == 'skip1':
+            t = next_slot_skip(slots, t, 32, 1)  # dst read: skip one slot
+        elif variant == 'd48':
+            t = next_slot(slots, t, 48)
+        elif variant == 'd64':
+            t = next_slot(slots, t, 64)
+        if t >= window: return count
+        t = next_slot(slots, t, 24)              # write
+        if t >= window: return count
+        count += 1; col += 1
+        d = 64 + (64 if col == nx else 0)
+        if col == nx: col = 0
+        t = next_slot(slots, t, d)               # next src read
+        if t >= window: return count
+
+REAL_LMMM = {('NORMAL','land'):1339, ('NORMAL','port'):1332,
+             ('NO_SPR','land'):1971, ('NO_SPR','port'):1955,
+             ('NO_SCR','land'):2004, ('NO_SCR','port'):1993}
+OMSX_LMMM = {('NORMAL','land'):1717, ('NORMAL','port'):1699,
+             ('NO_SPR','land'):1970, ('NO_SPR','port'):1954,
+             ('NO_SCR','land'):2003, ('NO_SCR','port'):1992}
+
+print('LMMM rule variants (sim, start offset 300):')
+print(f"{'table':8}{'or':6}{'base':>7}{'skip1':>7}{'d48':>7}{'d64':>7}{'openMSX':>9}{'real':>7}")
+for tname, slots in TABLES.items():
+    for orient, nx in GEOM.items():
+        row = [simulate_lmmm_variant(slots, nx, ACTIVE_WINDOW, 300, v)
+               for v in ('base','skip1','d48','d64')]
+        print(f"{tname:8}{orient:6}" + ''.join(f'{r:7d}' for r in row)
+              + f"{OMSX_LMMM[(tname,orient)]:9d}{REAL_LMMM[(tname,orient)]:7d}")
+
+# ---------------------------------------------------------------------------
+# Final verification: candidate rule = "in sprites-on mode, LMMM's dst read
+# happens at the first slot >= srcRead + 48 (instead of +32)". All other
+# commands/modes unchanged. Also verify VBLANK windows (screen-off table).
+# ---------------------------------------------------------------------------
+def sim_cmd(slots, cmd, nx, window, start, lmmm_rr):
+    spec = COMMANDS[cmd]
+    deltas = list(spec['deltas'])
+    if cmd == 'LMMM':
+        deltas[0] = lmmm_rr
+    wrap_extra = spec['wrap_extra']
+    t = next_slot(slots, start, 0)
+    count = 0; col = 0
+    while True:
+        for j, d in enumerate(deltas):
+            if t >= window: return count
+            if j == len(deltas) - 1:
+                count += 1; col += 1
+                dd = d + (wrap_extra if col == nx else 0)
+                if col == nx: col = 0
+                t = next_slot(slots, t, dd)
+            else:
+                t = next_slot(slots, t, d)
+
+print('FINAL: all commands, rule = LMMM R->R 48 in sprites-on only')
+print(f"{'cond':8}{'cmd':6}{'or':6}{'sim-old':>8}{'sim-new':>8}{'openMSX':>8}{'real':>7}")
+ALL = [('NORMAL', MEASURED_ACTIVE), ('NO_SPR', MEASURED_ACTIVE_NOSPR),
+       ('NO_SCR', MEASURED_ACTIVE_NOSCR)]
+for cond, meas in ALL:
+    slots = TABLES[cond]
+    for (cmd, orient), (omsx, real) in meas.items():
+        nx = GEOM[orient]
+        old = sim_cmd(slots, cmd, nx, ACTIVE_WINDOW, 300, 32)
+        rr = 48 if cond == 'NORMAL' else 32
+        new = sim_cmd(slots, cmd, nx, ACTIVE_WINDOW, 300, rr)
+        mark = ' <-- ' if abs(new-real) > 25 else ''
+        print(f'{cond:8}{cmd:6}{orient:6}{old:8d}{new:8d}{omsx:8d}{real:7d}{mark}')
+
+# VBLANK (screen-off table, PAL: 121 lines), THIS/REAL from run:
+VB = {('HMMM','land'):(1808,1801), ('LMMM','land'):(1273,1265),
+      ('YMMM','land'):(2532,2512), ('HMMV','land'):(3367,3360),
+      ('LMMV','land'):(1689,1684),
+      ('HMMM','port'):(1771,1765), ('LMMM','port'):(1266,1258),
+      ('YMMM','port'):(2531,2461), ('HMMV','port'):(3236,3229),
+      ('LMMV','port'):(1664,1659)}
+print('\nVBLANK PAL (121 lines, screen-off table):')
+print(f"{'cmd':6}{'or':6}{'sim':>7}{'openMSX':>8}{'real':>7}")
+for (cmd, orient), (omsx, real) in VB.items():
+    sim = sim_cmd(SLOTS_SCREEN_OFF, cmd, GEOM[orient], VBLANK_WINDOW_PAL, 300, 32)
+    print(f'{cmd:6}{orient:6}{sim:7d}{omsx:8d}{real:7d}')

--- a/doc/internal/vdp-cmd-timing-issue2057-sim.py
+++ b/doc/internal/vdp-cmd-timing-issue2057-sim.py
@@ -3,8 +3,8 @@
 VDPAccessSlots.cc) and compare with vdpcmdx measurements (issue #2057).
 
 Model: each VRAM access happens on an access slot. After an access at time t,
-the next access happens at the first slot >= t + delta (deltas from the VDP
-VRAM timing paper by Wouter Vermaelen / m9710797, hosted on map.grauw.nl). Line length = 1368 VDP ticks.
+the next access happens at the first slot >= t + delta (delta from Grauw's
+measurements). Line length = 1368 VDP ticks.
 """
 import bisect
 
@@ -245,7 +245,7 @@ for (cmd, orient), (omsx, real) in VB.items():
     print(f'{cmd:6}{orient:6}{sim:7d}{omsx:8d}{real:7d}')
 
 # ---------------------------------------------------------------------------
-# Caveat 1: the paper's allocation model (slots allocated 16 cycles in advance,
+# Caveat 1: Grauw's allocation model (slots allocated 16 cycles in advance,
 # CPU priority, engine request buffer) under vdpcmdx's CPU hammering
 # (OUT (#98),A = 72 VDP cycles period). 'pipelined=True' posts the next
 # engine request relative to the previous *request* instead of the access
@@ -294,7 +294,7 @@ def paper_model(slots, cmd, nx, window, cpu_period=None, cpu_phase=0,
 # ---------------------------------------------------------------------------
 # Caveat 2: YMMM delta fit. Grid search over (R->W, W->R, per-line extra)
 # against all 8 non-CPU measurements: best fit (36, 24, +64), max err 1.44%.
-# The paper's published '40 R 24 W', per-line 0 (max err 24%) has the two
+# Grauw's published '40 R 24 W', per-line 0 (max err 24%) has the two
 # inter-access values effectively swapped and misses the per-line overhead.
 # On the sprites-on table both variants give the same read cadence.
 # ---------------------------------------------------------------------------
@@ -309,3 +309,22 @@ def sim_ymmm(slots, nx, window, d_rw, d_wr, wrap, start=300):
         if col == nx: col = 0
         t = next_slot(slots, t, d)             # next read
         if t >= window: return count
+
+# ---------------------------------------------------------------------------
+# Constraint bands (addendum 5): what the vdpcmdx data actually pins down.
+# LMMM sprites-on dst read: any threshold in 33..65 fits (48 implemented).
+# YMMM: two families within 2% of all 8 cells (1-cycle-resolution search):
+#   A: R->W 33..38, W->R 17..24, line 56..88 (best 1.44%)
+#   B: R->W 17..24, W->R 33..38, line 64..88 (best 0.64%)  <- implemented
+#     as read -24-> write -36-> next read, +68 per line (= D24/D36/D104).
+# Equivalent-time-sampling test (completion time vs start phase, 6-cycle
+# sweep): YMMM A-vs-B differ at 212/228 phases (<=58 cycles); LMMM D48 vs
+# middle-slot-shift differ at 32..38/228 phases (<=52 cycles); YMMM band
+# splits into {33,34},{35,36},{37,38} via the 10-cycle end-of-line gaps.
+def completion_fingerprint(slots, phase, accesses):
+    """Completion time of a short command started at 'phase'; 'accesses' is
+    the flat list of deltas before each access after the first."""
+    t = next_slot(slots, phase, 0)
+    for d in accesses:
+        t = next_slot(slots, t, d)
+    return t - phase

--- a/doc/internal/vdp-cmd-timing-issue2057-sim.py
+++ b/doc/internal/vdp-cmd-timing-issue2057-sim.py
@@ -3,8 +3,8 @@
 VDPAccessSlots.cc) and compare with vdpcmdx measurements (issue #2057).
 
 Model: each VRAM access happens on an access slot. After an access at time t,
-the next access happens at the first slot >= t + delta (delta from Grauw's
-measurements). Line length = 1368 VDP ticks.
+the next access happens at the first slot >= t + delta (deltas from the VDP
+VRAM timing paper by Wouter Vermaelen / m9710797, hosted on map.grauw.nl). Line length = 1368 VDP ticks.
 """
 import bisect
 
@@ -245,7 +245,7 @@ for (cmd, orient), (omsx, real) in VB.items():
     print(f'{cmd:6}{orient:6}{sim:7d}{omsx:8d}{real:7d}')
 
 # ---------------------------------------------------------------------------
-# Caveat 1: Grauw's allocation model (slots allocated 16 cycles in advance,
+# Caveat 1: the paper's allocation model (slots allocated 16 cycles in advance,
 # CPU priority, engine request buffer) under vdpcmdx's CPU hammering
 # (OUT (#98),A = 72 VDP cycles period). 'pipelined=True' posts the next
 # engine request relative to the previous *request* instead of the access
@@ -294,7 +294,7 @@ def paper_model(slots, cmd, nx, window, cpu_period=None, cpu_phase=0,
 # ---------------------------------------------------------------------------
 # Caveat 2: YMMM delta fit. Grid search over (R->W, W->R, per-line extra)
 # against all 8 non-CPU measurements: best fit (36, 24, +64), max err 1.44%.
-# Grauw's published '40 R 24 W', per-line 0 (max err 24%) has the two
+# The paper's published '40 R 24 W', per-line 0 (max err 24%) has the two
 # inter-access values effectively swapped and misses the per-line overhead.
 # On the sprites-on table both variants give the same read cadence.
 # ---------------------------------------------------------------------------

--- a/doc/internal/vdp-cmd-timing-issue2057-sim.py
+++ b/doc/internal/vdp-cmd-timing-issue2057-sim.py
@@ -243,3 +243,69 @@ print(f"{'cmd':6}{'or':6}{'sim':>7}{'openMSX':>8}{'real':>7}")
 for (cmd, orient), (omsx, real) in VB.items():
     sim = sim_cmd(SLOTS_SCREEN_OFF, cmd, GEOM[orient], VBLANK_WINDOW_PAL, 300, 32)
     print(f'{cmd:6}{orient:6}{sim:7d}{omsx:8d}{real:7d}')
+
+# ---------------------------------------------------------------------------
+# Caveat 1: Grauw's allocation model (slots allocated 16 cycles in advance,
+# CPU priority, engine request buffer) under vdpcmdx's CPU hammering
+# (OUT (#98),A = 72 VDP cycles period). 'pipelined=True' posts the next
+# engine request relative to the previous *request* instead of the access
+# (bounded below by the access itself) — the starved-engine limit.
+# ---------------------------------------------------------------------------
+def paper_model(slots, cmd, nx, window, cpu_period=None, cpu_phase=0,
+                lmmm_dst_p=None, pipelined=False):
+    spec = COMMANDS[cmd]
+    deltas = list(spec['deltas'])
+    if cmd == 'LMMM' and lmmm_dst_p is not None:
+        deltas[0] = lmmm_dst_p
+    wrap_extra = spec['wrap_extra']
+    n = len(slots)
+    acc_idx = 0; col = 0; count = 0
+    eng_req = 0; eng_post = 0
+    line = 0; i = 0
+    cpu_next = cpu_phase; cpu_pending = None
+    while True:
+        s = line * LINE + slots[i]
+        alloc = s - 16
+        if alloc >= window: return count
+        while cpu_period and cpu_next <= alloc:
+            cpu_pending = cpu_next; cpu_next += cpu_period
+        if cpu_period and cpu_pending is not None:
+            cpu_pending = None                    # CPU takes the slot
+        elif eng_req <= alloc:
+            if s >= window: return count
+            d = deltas[acc_idx]
+            if acc_idx == len(deltas) - 1:
+                count += 1; col += 1
+                if col == nx: col = 0; d += wrap_extra
+            acc_idx = (acc_idx + 1) % len(deltas)
+            nxt = max(eng_post + (d - 16), s) if pipelined else s + (d - 16)
+            eng_post = nxt; eng_req = nxt
+        i += 1
+        if i == n: i = 0; line += 1
+
+# Key results (sprites-on, ACTIVE window, CPU period 72):
+#   pipelined variant, phase-independent, matches real HW within ~1%:
+#     HMMM 1152 (real 1160), LMMM 768 with dst 32 OR 48 (real 774),
+#     YMMM 1152 (1167), HMMV 2304 (2310), LMMV 1152 (1158)
+#   = exact slot saturation: engine gets (31 - 19) slots/line.
+#   The current openMSX stealAccessSlot model is phase-fragile instead
+#   (same build measured 1156 vs 970 for HMMM+CPU on different runs).
+
+# ---------------------------------------------------------------------------
+# Caveat 2: YMMM delta fit. Grid search over (R->W, W->R, per-line extra)
+# against all 8 non-CPU measurements: best fit (36, 24, +64), max err 1.44%.
+# Grauw's published '40 R 24 W', per-line 0 (max err 24%) has the two
+# inter-access values effectively swapped and misses the per-line overhead.
+# On the sprites-on table both variants give the same read cadence.
+# ---------------------------------------------------------------------------
+def sim_ymmm(slots, nx, window, d_rw, d_wr, wrap, start=300):
+    t = next_slot(slots, start, 0)
+    count = 0; col = 0
+    while True:
+        t = next_slot(slots, t, d_rw)          # write, d_rw after read
+        if t >= window: return count
+        count += 1; col += 1
+        d = d_wr + (wrap if col == nx else 0)
+        if col == nx: col = 0
+        t = next_slot(slots, t, d)             # next read
+        if t >= window: return count

--- a/doc/internal/vdp-cmd-timing-issue2057.md
+++ b/doc/internal/vdp-cmd-timing-issue2057.md
@@ -325,3 +325,76 @@ How to validate on real hardware:
   validation.
 - More chips: V9958 machines and other V9938 batches, to see whether the
   behavior is uniform.
+
+## Addendum 2026-07-22 (5): constraint bands, not point values; a pinning test
+
+Review feedback (rightly) criticized presenting fitted point values as
+conclusions. This section states what the measurements actually
+constrain, corrects an overclaim in addendum (3), and proposes a new
+hardware test that pins the values further.
+
+### What the data actually pins down
+
+LMMM, sprites-on destination read (under the conditional-delta
+hypothesis): any effective minimum spacing in **33..65** cycles
+reproduces the measurements (1341/1334 sim vs 1339/1332 real); 32 gives
+1724/1706 and >=66 gives 1149/1144. The implemented `D48` is one
+representative. The slot-table-shift hypothesis of addendum (4) remains
+an equivalent alternative.
+
+YMMM: exhaustive search at 1-cycle resolution finds exactly two
+solution families within 2% of all 8 non-CPU measurements:
+
+- family A: R->W in 33..38, W->R in 17..24, per-line 56..88
+  (best member 1.44%) — the "swapped values" reading of addendum (3);
+- family B: R->W in 17..24, W->R in 33..38, per-line 64..88
+  (best member 0.64%).
+
+The "swapped" claim in addendum (3) was too strong: family B keeps the
+paper's R->W = 24 unchanged and only replaces the 40 with a value in
+33..38 — it deviates less from the paper AND fits better. The
+implementation now uses family B: read -D24-> write -D36-> next read,
+D104 (= 36 + 68) at line wrap. Emulator verification (vdpcmdx, THIS vs
+REAL): NORMAL 2109/2111 and 2093/2095, NO-SPR 3796/3797 and 3686/3689,
+NO-SCR 3994/3996 and 3912/3914, VBLANK 2523/2512 and 2471/2461 — every
+YMMM cell within 3 pixels.
+
+Note both anomalies are consistent with a threshold "strictly more than
+32" (LMMM band 33..65, YMMM band 33..38 both contain 33), which could
+point at an exclusive boundary in slot granting rather than a new delay
+value — but the YMMM band's upper limit 38 and the LMMM dense-table
+behavior (exactly 32 works there) mean neither is a clean universal
+rule yet.
+
+### Proposed test: equivalent-time sampling of command completion
+
+vdpcmdx measures whole-frame throughput, which cannot separate
+solutions inside the bands above. The following software-only test can
+(no logic analyzer needed):
+
+1. HALT-sync to the line interrupt (deterministic Z80 interrupt
+   latency), then burn a programmable number of cycles with a NOP sled.
+2. Start a tiny command (e.g. YMMM of 4 pixels, or LMMM of 1 pixel) at
+   that controlled phase within the scanline.
+3. Read S#2 once at a second programmable delay and record the CE bit
+   (busy/done — a single binary sample, no polling loop).
+4. Sweep both delays in 1-Z80-cycle (6 VDP cycles) steps over many
+   frames. The CE transition point as a function of start phase is a
+   fingerprint of the engine's per-access slot usage.
+
+Simulated discrimination power (completion-time difference >= 12 VDP
+cycles, sweeping the 228 possible start phases):
+
+- YMMM family A vs family B (4 px, sprites off): 212/228 phases differ,
+  up to 58 cycles — trivially separable.
+- LMMM conditional-D48 vs shifted-slot-table (1 px, sprites on): 32..38
+  of 228 phases differ, up to 52 cycles — separable at specific phases.
+- Within the YMMM 33..38 band: the 10-cycle slot gaps near the end of
+  the sprites-off line make {33,34} vs {35,36} vs {37,38} separable
+  (1-2 phases each); inside those pairs natural slot geometry offers no
+  discriminating offsets, so the exact value needs a bus-level capture.
+
+The same setup with NY=2 vs NY=1 measures the per-line overhead
+directly, and with delay-0 it measures the command startup overhead —
+i.e. it also addresses gap 1 of the original analysis, which no
+existing test covers.

--- a/doc/internal/vdp-cmd-timing-issue2057.md
+++ b/doc/internal/vdp-cmd-timing-issue2057.md
@@ -202,7 +202,72 @@ Known remaining deviations (pre-existing, out of scope for this fix):
   above): with CPU slot-stealing in play, the D48 rule overshoots. A
   proper fix needs the reserve-16-cycles-ahead CPU-priority model, at
   which point the LMMM rule may fall out of the same mechanism.
+  ANALYZED AND EXPLAINED in addendum (3) below.
 - YMMM with sprites off is ~25% too SLOW in openMSX (2870 vs real
   3797 landscape, 2871 vs 3689 portrait) — real HW is much faster than
-  Grauw's '40R 24W' deltas allow on the 88-slot table. Untouched here;
-  deserves its own investigation and possibly re-measurement.
+  Grauw's '40R 24W' deltas allow on the 88-slot table.
+  ANALYZED AND FIXED in addendum (3) below.
+
+## Addendum 2026-07-20 (3): both remaining deviations analyzed
+
+### YMMM: Grauw's deltas are wrong — fixed
+
+No (R->W, W->R) delta pair with zero line overhead fits the
+measurements (best possible: 19% error). Extending the search with a
+per-line overhead parameter finds that
+
+    read -36-> write -24-> next read, +64 extra per line
+
+fits ALL eight non-CPU YMMM measurements (sprites on/off, screen off,
+vblank, both orientations) within 1.44%, where the current model
+('24 R->W, 40 W->R, 0 per line', from Grauw's table entry
+'YMMM | 40 R 24 W | 0') is up to 24% off. In other words: the two
+inter-access values in the published table are effectively swapped,
+and YMMM does have a per-line overhead (~64 cycles, like the other
+block commands) contrary to the paper's note. On the sprites-enabled
+slot table both timings happen to produce the identical read cadence,
+which is probably why the error was never noticed there. The odd value
+36 (not a multiple of 8) is what the fit requires to use the
+second-slot-of-a-pair positions (38 cycles apart) on the sprites-off
+table; the true hardware rule behind it is unknown.
+
+Implemented: new `Delta::D36` in `VDPAccessSlots.hh/.cc`, and
+`executeYmmm` now does read -D36-> write -D24-> read (D88 = 24+64 at
+line wrap). Verified with vdpcmdx (THIS vs REAL): NO-SPR 3804/3797
+(was 2870) and 3725/3689 (was 2871); NORMAL 2107/2111, 2085/2095;
+NO-SCR 3994/3996, 3912/3914 (portrait was 4012); VBLANK 2523/2512,
+2470/2461 (portrait was 2531). YMMM NORMAL+CPU still matches
+(1165/1167, 1166/1166).
+
+### LMMM+CPU (and all +CPU columns): artifact of the contention model
+
+The real-hardware +CPU numbers have a simple structure. The hammering
+loop (`OUT (#98),A` = 12 Z80 = 72 VDP cycles) issues exactly 19 CPU
+requests per 1368-cycle line. In sprites-on mode real HW then shows
+*exact slot saturation*: every command gets the remaining
+31 - 19 = 12 slots per line, i.e. 12/accesses-per-pixel pixels per
+line — HMMM/LMMV/YMMM 6.0 px/line (real 1158..1167 per frame), LMMM
+4.0 (774), HMMV 12.0 (2310). All five confirmed within 1%.
+
+Simulating Grauw's real allocation model (slot granted at its
+allocation point 16 cycles ahead; CPU priority; engine stalls on a
+pending request; see `paper_model` in the sim script) reproduces this:
+in the starved-engine limit the engine request is always pending, so
+it takes every CPU-free slot, phase-independently — and then it does
+NOT matter whether LMMM's dst-read delta is 32 or 48 (both give 768 vs
+real 774). Conclusions:
+
+- The 774->679 regression from the LMMM D48 fix exists only in
+  openMSX's simplified `stealAccessSlot` model; under the correct
+  allocation model the D48 rule is harmless with CPU load.
+- The current model is also phase-fragile: because 72 divides 19x into
+  1368, the CPU pattern phase-locks to the line, and the same build
+  produced e.g. 1156 vs 970 for HMMM NORMAL+CPU on two different runs
+  (real HW: 1160, stable). The erratic +CPU cells across openMSX runs
+  are this resonance.
+- The proper fix for every +CPU cell is implementing the paper's
+  allocation model (gap 2 in the original analysis): per-slot
+  allocation 16 cycles ahead, separate CPU/engine request buffers, CPU
+  priority, CPU request dropping. That is the invasive hot-path rework
+  the maintainer warned about; it should replace `stealAccessSlot`.
+  No code change made for this here.

--- a/doc/internal/vdp-cmd-timing-issue2057.md
+++ b/doc/internal/vdp-cmd-timing-issue2057.md
@@ -398,3 +398,48 @@ The same setup with NY=2 vs NY=1 measures the per-line overhead
 directly, and with delay-0 it measures the command startup overhead —
 i.e. it also addresses gap 1 of the original analysis, which no
 existing test covers.
+
+## Addendum 2026-07-24 (6): cross-check against the 2013 raw captures
+
+Wouter Vermaelen published the original measurement data:
+https://github.com/m9710797/vdp-timing-measurements. Checking the YMMM
+conclusions of this analysis against those raw captures
+(8.final-analysis/*YMMM*.txt, parsed with
+`vdp-cmd-timing-issue2057-capture-check.py`):
+
+- Steady-state gaps: R->W = 24 (with a few 26), W->R = 40 (with
+  slot-availability variants 42/44/56). Fully consistent with the
+  implemented model: all YMMM captures are in screen-off mode, where
+  every W->R threshold in 33..40 realizes as exactly 40 on the 8-cycle
+  slot grid — the captures cannot distinguish 36 from 40 (the writeup
+  itself notes the method's 8-cycle accuracy). The value <=38 is pinned
+  only by the vdpcmdx sprites-off cells (the slots 38 cycles after a
+  write on that table).
+
+- Per-line overhead: the 2013 captures CONFIRM it. Three
+  rectangle-line-transition events exist in the captures
+  (screen5screenoffYMMM3, screen8screenoffYMMM1, screen8screenoffYMMM6),
+  recognizable by the read address crossing a VRAM line boundary
+  (0x0e47f->0x0e480 with 128-byte lines, 0x185ff->0x18600 and
+  0x1e8ff->0x1e900 with 256-byte lines). Their W->R gaps are 108, 104,
+  108 cycles instead of 40 — an extra ~64-68 cycles, exactly the fitted
+  wrap value. The implemented D104 (36+68) predicts the observed
+  next-read slot positions cycle-exactly in all three cases (cycles 33,
+  805, 165). Each ~4-line capture contains only one such event, which
+  is presumably why the original analysis concluded 'no per-line
+  overhead' for YMMM.
+
+- Coverage: the 2013 command captures are all screen-off (plus HMMV in
+  other modes). There are NO sprites-on LMMM captures and NO sprites-off
+  YMMM captures — precisely the two configurations where vdpcmdx found
+  discrepancies. The 2013 data and the vdpcmdx data are therefore fully
+  consistent with each other and with the implemented model; each
+  covers the other's blind spot.
+
+Direction clarification (review question): vdpcmdx's THIS column is
+openMSX and REAL is hardware; for YMMM sprites-off THIS < REAL
+(2870 < 3797), i.e. openMSX was too SLOW there, while slightly too fast
+in the portrait screen-off/vblank cells. The change speeds up the
+steady state only where slots 33..38 cycles after a write exist (the
+sprites-off table) and slows down line transitions everywhere — which
+is what the per-line overhead events in the 2013 captures show.

--- a/doc/internal/vdp-cmd-timing-issue2057.md
+++ b/doc/internal/vdp-cmd-timing-issue2057.md
@@ -1,0 +1,208 @@
+# Analysis: VDP command timings differ from real HW (issue #2057)
+
+Analysis of https://github.com/openMSX/openMSX/issues/2057, 2026-07-18.
+Status: report only, no code changes made yet.
+Update 2026-07-20: see "Addendum" at the bottom — new measurements narrow
+the discrepancy to LMMM in the active area with sprites enabled.
+
+## What the issue is
+
+bengalack built a test ROM (https://github.com/bengalack/cmd_timings) that
+colors the screen border while the V9938 command engine is busy (white) and
+while the CPU pushes VRAM data (red). Comparing openMSX 21 against real
+hardware (NMS-8245, FS-A1, HB-F1XDJ) shows openMSX completes VDP block
+commands (LMMM/HMMM) too fast — both with concurrent CPU VRAM access and in
+command-only cases with small copy blocks. Real hardware additionally shows
+heavy jitter (up to ~14 scanlines / ~3200 cycles) when CPU and command engine
+compete, which openMSX does not reproduce.
+
+Maintainer assessment (m9710797): probably not a parameter to tweak but a
+missing rule in the model, and a lot of measurement-driven work.
+
+## How openMSX models command timing today
+
+The model is directly derived from Grauw's VDP VRAM timing paper (in-tree
+copy: doc/internal/vdp-vram-timing/vdp-timing.html) and lives in:
+
+- `src/video/VDPAccessSlots.cc` — tables of the real VRAM access-slot
+  positions within the 1368-cycle scanline, per mode (154 slots screen-off,
+  88 sprites-off, 31 sprites-on, etc.), precompiled into a "cycles until next
+  slot at least N cycles away" lookup table.
+- `src/video/VDPCmdEngine.cc` — each block command walks pixel by pixel;
+  every VRAM access advances `engineTime` to the next real slot with the
+  per-access minimum delays from Grauw's measurements (LMMM = 64R/32R/24W per
+  pixel + 64 per line, etc. — the constants match the paper exactly).
+  Execution is lazy: the engine only advances when software observes it
+  (status register S#2, VRAM access, register writes).
+- CPU contention: a CPU VRAM access calls `stealAccessSlot()`
+  (`src/video/VDPVRAM.hh` cpuRead/cpuWrite -> `VDPCmdEngine.hh`), which
+  pushes the engine's next access to the following slot. CPU accesses
+  themselves are scheduled ~16 cycles ahead at the next slot
+  (`VDP.cc` scheduleCpuVramAccess).
+
+This core has been essentially unchanged since 2013-2015.
+
+## The gaps — what would need to be improved
+
+Ranked by likelihood of explaining the reported discrepancy:
+
+1. **No command-startup / first-line overhead.** Every `start*` function
+   (e.g. `startLmmm`) begins the first pixel at the very next access slot
+   with zero setup cost. Grauw's paper explicitly flags this as unmeasured
+   and says it is logical to assume the per-line overhead (64 cycles for
+   LMMM) also applies at command start, possibly plus a per-command
+   constant. Best candidate for the command-only discrepancy the issue
+   demonstrates with small blocks — a fixed missing startup cost matters
+   most there.
+
+2. **Simplified CPU vs command-engine contention.** In real hardware the VDP
+   allocates slots 16 cycles in advance with CPU priority, and a slot can go
+   unused entirely; openMSX just bumps the engine by one slot per CPU
+   access. This under-penalizes commands under concurrent CPU load and
+   cannot reproduce the large jitter seen on real hardware. Best candidate
+   for the CMD+CPU discrepancy.
+
+3. **CPU-transfer commands are knowingly wrong.** LMMC/HMMC/LMCM carry
+   comments like "timing is inaccurate, this executes the read and write in
+   the same access slot" and effectively skip slot accounting. Not what the
+   issue measures (it uses LMMM/HMMM), but part of the same cleanup.
+
+4. **Minor:** openMSX implements Grauw's *minimum* measured delays; if real
+   chips have systematic overhead above those minimums, everything runs
+   slightly fast. Also SRCH/PSET deltas are marked `// TODO`, and the ImGui
+   block-command overlay is approximate by design
+   (`src/imgui/ImGuiBitmapViewer.cc` top comment) — which is the "overlay
+   not 100% precise" remark in the issue thread.
+
+## What a fix would involve
+
+- Calibrate against the cmd_timings ROM: run it in openMSX, count CE-busy
+  cycles per configuration, and compare with the line counts visible in the
+  issue's real-hardware photos to estimate the missing constant(s) per
+  command.
+- Add a start-of-command overhead (likely = the per-line delta, possibly
+  plus a constant) in each `start*` function — small, low-risk change once
+  the value is known.
+- Rework `stealAccessSlot` toward the paper's reserve-16-cycles-ahead,
+  CPU-priority model — more invasive, touches the hot path, needs regression
+  testing against timing-sensitive titles (the code cites a Chase HQ
+  regression from a past tweak).
+- Ideally new measurements on real hardware, since the paper's data does not
+  cover startup latency at all.
+
+## Key code anchors
+
+- Per-pixel/per-line deltas and finish estimate:
+  `src/video/VDPCmdEngine.cc` (`calcFinishTime`, `startLmmm`/`executeLmmm`)
+- Slot tables and table selection: `src/video/VDPAccessSlots.cc`
+- CPU/command contention: `src/video/VDPVRAM.hh` (cpuRead/cpuWrite),
+  `VDPCmdEngine.hh` (`stealAccessSlot`), `VDP.cc` (`scheduleCpuVramAccess`)
+- Accuracy settings: `src/video/RenderSettings.cc` (`cmdtiming`,
+  `too_fast_vram_access`)
+
+## Addendum 2026-07-20: vdpcmdx measurements narrow the problem
+
+bengalack published a follow-up tool, vdpcmdx
+(https://github.com/bengalack/vdpcmdx), which counts pixels the command
+engine produces per frame (screen 8, 192 lines), separately for VBLANK and
+the active area, across HMMM/LMMM/YMMM/HMMV/LMMV with sprites on
+("NORMAL"), sprites off, screen off, and with/without concurrent CPU VRAM
+access. "REAL" reference numbers come from a Sony HB-F1XD.
+
+Reproduced locally (openMSX 21.0-77, Philips_NMS_8250, 50Hz, MSX-DOS,
+vdpcmdx.com). Result matches the numbers posted in the issue:
+
+- The ONLY significant deviation is **LMMM, active area, sprites enabled,
+  no CPU access**: openMSX ~1717/1699 pixels per frame vs ~1339/1332 on
+  real HW — about 28% too fast.
+- Everything else is within ~1%: all VBLANK rows, all HMMM/HMMV/LMMV/YMMM
+  rows, and — notably — LMMM active area with sprites OFF (1970 vs 1971)
+  and screen OFF (2003 vs 2004), and even LMMM active + CPU (775 vs 774).
+- Known secondary deviations also visible in both runs: YMMM active area
+  with sprites off is too SLOW in openMSX (~2870 vs ~3797 real), and some
+  +CPU cells differ in both directions — consistent with gap 2 (contention
+  model) being separately imperfect.
+
+Consequences for the ranking above:
+
+- Gap 1 (startup overhead) is NOT the explanation for this measurement:
+  vdpcmdx measures sustained throughput over a whole frame (startup cost is
+  amortized), and the VBLANK numbers match. It may still matter for the
+  original cmd_timings small-block cases, but it cannot produce a 28%
+  active-area-only error.
+- The failing case is exactly the sprites-enabled slot table (31 slots per
+  line, `VDPAccessSlots.cc`). Since sprites-off (88 slots) and screen-off
+  (154 slots) match perfectly, the per-access minimum deltas
+  (64R/32R/24W for LMMM) are correct; what is wrong is how LMMM's
+  3-accesses-per-pixel pattern interacts with the sparse sprites-on slot
+  distribution. openMSX's "jump to next slot at least N cycles away" model
+  is too optimistic there: real HW achieves ~7.0 px/line vs openMSX's
+  ~8.9 px/line (theoretical min-delta cap is ~11.4). HMMM (1 access/pixel
+  pair) and the fill commands are unaffected, so the missing rule is
+  specific to multi-access-per-pixel commands on the 31-slot table —
+  e.g. real HW may be unable to use closely spaced slot pairs
+  back-to-back the way the greedy model assumes.
+- Practical next step: instrument `executeLmmm` slot usage in the
+  sprites-on mode and compare achieved slots/line (~21 real vs ~27
+  openMSX) against the 31-slot table to find which slots real HW skips.
+
+## Addendum 2026-07-20 (2): the missing rule, found and implemented
+
+Method: an offline simulator of the openMSX slot model
+(`vdp-cmd-timing-issue2057-sim.py`, same directory) replicates
+`VDPAccessSlots.cc` + the per-command deltas and the exact vdpcmdx test
+geometry (screen 8, landscape 256x40 / portrait 40x256, command window =
+exactly the 192 active lines, per vdpcmdx `main.c`). It reproduces the
+emulator's own results on all 30 non-CPU data points within ~0.5%, which
+validates the simulator. Rule variants were then tested against the
+real-hardware numbers.
+
+Result — a single minimal rule reproduces real HW within +-2 pixels:
+
+    LMMM's source-read -> destination-read spacing is >= 48 cycles
+    (not >= 32) when sprite rendering is enabled. All other commands
+    and all other modes keep Grauw's published deltas.
+
+Evidence and eliminated alternatives:
+
+- LMMM is the only measured command with two back-to-back *reads*;
+  every command whose transitions are read->write or write->read is
+  timed correctly by the current model in every mode.
+- A slot-index rule ("skip one slot") gives 1245 px/frame, too slow; the
+  measured 1339 requires a time-based >=48 rule (an adjacent slot >=48
+  cycles away IS used, e.g. slot 92 -> 162).
+- Applying 48 globally (all modes) breaks sprites-off (1659 vs 1971)
+  and screen-off (1851 vs 2004), so the +16 penalty only exists with
+  the sprite-fetch pattern on the bus. Grauw's paper already hints at
+  related unexplained behavior: the sprites-on slot at cycle 170 is
+  "rarely actually used" on real HW even when the engine is starved.
+  The physical mechanism (likely an interaction between the engine's
+  request pipeline and sprite fetches) remains unknown; the 48 is a
+  calibrated, verified description of the behavior.
+
+Implementation: `VDPCmdEngine.cc` `executeLmmm` now selects
+`Delta::D48` instead of `Delta::D32` for the destination read when the
+current mode uses the sprites-on slot table (same predicate as
+`VDPAccessSlots::getTab`: V99x8, bitmap mode, display enabled, sprites
+enabled).
+
+Verification (vdpcmdx in the patched build, Philips_NMS_8250, 50Hz):
+
+- ACTIVE/NORMAL Copy LMMM: 1339 vs real 1339 (landscape),
+  1333 vs 1332 (portrait). Before the fix: 1717 / 1699 (~28% too fast).
+- All other rows unchanged, still matching real HW within ~1%
+  (HMMM 1915/1915, YMMM 2111/2111, HMMV 4002/4005, LMMV 1907/1908, all
+  VBLANK/NO-SPR/NO-SCR rows).
+
+Known remaining deviations (pre-existing, out of scope for this fix):
+
+- LMMM ACTIVE NORMAL+CPU landscape regressed from 774 (matching) to
+  679 (real: 774); portrait was already off (681 vs 775, now 679).
+  This column exercises the simplified CPU contention model (gap 2
+  above): with CPU slot-stealing in play, the D48 rule overshoots. A
+  proper fix needs the reserve-16-cycles-ahead CPU-priority model, at
+  which point the LMMM rule may fall out of the same mechanism.
+- YMMM with sprites off is ~25% too SLOW in openMSX (2870 vs real
+  3797 landscape, 2871 vs 3689 portrait) — real HW is much faster than
+  Grauw's '40R 24W' deltas allow on the 88-slot table. Untouched here;
+  deserves its own investigation and possibly re-measurement.

--- a/doc/internal/vdp-cmd-timing-issue2057.md
+++ b/doc/internal/vdp-cmd-timing-issue2057.md
@@ -21,7 +21,9 @@ missing rule in the model, and a lot of measurement-driven work.
 
 ## How openMSX models command timing today
 
-The model is directly derived from Grauw's VDP VRAM timing paper (in-tree
+The model is directly derived from the VDP VRAM timing paper by Wouter
+Vermaelen (m9710797, measurements together with Joost; hosted on
+map.grauw.nl) (in-tree
 copy: doc/internal/vdp-vram-timing/vdp-timing.html) and lives in:
 
 - `src/video/VDPAccessSlots.cc` — tables of the real VRAM access-slot
@@ -30,7 +32,7 @@ copy: doc/internal/vdp-vram-timing/vdp-timing.html) and lives in:
   slot at least N cycles away" lookup table.
 - `src/video/VDPCmdEngine.cc` — each block command walks pixel by pixel;
   every VRAM access advances `engineTime` to the next real slot with the
-  per-access minimum delays from Grauw's measurements (LMMM = 64R/32R/24W per
+  per-access minimum delays from the paper's measurements (LMMM = 64R/32R/24W per
   pixel + 64 per line, etc. — the constants match the paper exactly).
   Execution is lazy: the engine only advances when software observes it
   (status register S#2, VRAM access, register writes).
@@ -48,7 +50,7 @@ Ranked by likelihood of explaining the reported discrepancy:
 
 1. **No command-startup / first-line overhead.** Every `start*` function
    (e.g. `startLmmm`) begins the first pixel at the very next access slot
-   with zero setup cost. Grauw's paper explicitly flags this as unmeasured
+   with zero setup cost. The paper explicitly flags this as unmeasured
    and says it is logical to assume the per-line overhead (64 cycles for
    LMMM) also applies at command start, possibly plus a per-command
    constant. Best candidate for the command-only discrepancy the issue
@@ -67,7 +69,7 @@ Ranked by likelihood of explaining the reported discrepancy:
    the same access slot" and effectively skip slot accounting. Not what the
    issue measures (it uses LMMM/HMMM), but part of the same cleanup.
 
-4. **Minor:** openMSX implements Grauw's *minimum* measured delays; if real
+4. **Minor:** openMSX implements the paper's *minimum* measured delays; if real
    chips have systematic overhead above those minimums, everything runs
    slightly fast. Also SRCH/PSET deltas are marked `// TODO`, and the ImGui
    block-command overlay is approximate by design
@@ -161,7 +163,7 @@ Result — a single minimal rule reproduces real HW within +-2 pixels:
 
     LMMM's source-read -> destination-read spacing is >= 48 cycles
     (not >= 32) when sprite rendering is enabled. All other commands
-    and all other modes keep Grauw's published deltas.
+    and all other modes keep the paper's published deltas.
 
 Evidence and eliminated alternatives:
 
@@ -173,7 +175,7 @@ Evidence and eliminated alternatives:
   cycles away IS used, e.g. slot 92 -> 162).
 - Applying 48 globally (all modes) breaks sprites-off (1659 vs 1971)
   and screen-off (1851 vs 2004), so the +16 penalty only exists with
-  the sprite-fetch pattern on the bus. Grauw's paper already hints at
+  the sprite-fetch pattern on the bus. The paper already hints at
   related unexplained behavior: the sprites-on slot at cycle 170 is
   "rarely actually used" on real HW even when the engine is starved.
   The physical mechanism (likely an interaction between the engine's
@@ -205,12 +207,12 @@ Known remaining deviations (pre-existing, out of scope for this fix):
   ANALYZED AND EXPLAINED in addendum (3) below.
 - YMMM with sprites off is ~25% too SLOW in openMSX (2870 vs real
   3797 landscape, 2871 vs 3689 portrait) — real HW is much faster than
-  Grauw's '40R 24W' deltas allow on the 88-slot table.
+  the paper's '40R 24W' deltas allow on the 88-slot table.
   ANALYZED AND FIXED in addendum (3) below.
 
 ## Addendum 2026-07-20 (3): both remaining deviations analyzed
 
-### YMMM: Grauw's deltas are wrong — fixed
+### YMMM: the paper's deltas don't match — fixed
 
 No (R->W, W->R) delta pair with zero line overhead fits the
 measurements (best possible: 19% error). Extending the search with a
@@ -220,7 +222,7 @@ per-line overhead parameter finds that
 
 fits ALL eight non-CPU YMMM measurements (sprites on/off, screen off,
 vblank, both orientations) within 1.44%, where the current model
-('24 R->W, 40 W->R, 0 per line', from Grauw's table entry
+('24 R->W, 40 W->R, 0 per line', from the paper's table entry
 'YMMM | 40 R 24 W | 0') is up to 24% off. In other words: the two
 inter-access values in the published table are effectively swapped,
 and YMMM does have a per-line overhead (~64 cycles, like the other
@@ -249,7 +251,7 @@ requests per 1368-cycle line. In sprites-on mode real HW then shows
 line — HMMM/LMMV/YMMM 6.0 px/line (real 1158..1167 per frame), LMMM
 4.0 (774), HMMV 12.0 (2310). All five confirmed within 1%.
 
-Simulating Grauw's real allocation model (slot granted at its
+Simulating the paper's real allocation model (slot granted at its
 allocation point 16 cycles ahead; CPU priority; engine stalls on a
 pending request; see `paper_model` in the sim script) reproduces this:
 in the starved-engine limit the engine request is always pending, so
@@ -271,3 +273,55 @@ real 774). Conclusions:
   priority, CPU request dropping. That is the invasive hot-path rework
   the maintainer warned about; it should replace `stealAccessSlot`.
   No code change made for this here.
+
+## Addendum 2026-07-20 (4): answers to review questions (PR feedback)
+
+Attribution correction: the VRAM timing paper and its measurements are by
+Wouter Vermaelen (m9710797, together with Joost); map.grauw.nl only hosts
+the document. Earlier revisions of this file said "Grauw's paper".
+
+Three findings from re-testing the reviewer's alternative hypotheses in
+the simulator:
+
+1. "Always use D48 for LMMM?" — No: it breaks sprites-off (sim 1659 vs
+   real 1971) and screen-off (1851 vs 2004). The 32-cycle spacing is
+   definitely correct on the dense tables.
+
+2. "Maybe the sprites-on slot table is wrong instead?" — This WORKS as an
+   alternative explanation. Shifting only the middle slot of each
+   32/32-triplet (cycles 220, 348, 476, 604, 732, 860, 988, 1116) 4 or 8
+   cycles EARLIER reproduces all ten sprites-on measurements with the
+   original unconditional deltas — no conditional D48 needed:
+   LMMM 1341/1334 (real 1339/1332), HMMM 1918 (1915), YMMM 2109 (2111),
+   HMMV 4013/3930 (4005/3922), LMMV 1911/1872 (1908/1869). The vdpcmdx
+   data cannot distinguish "middle slots are 4-8 cycles earlier" from
+   "LMMM's dst read needs >32 cycles"; only a bus-level measurement can.
+   The key property either way: LMMV's write (>=24 after its read) must
+   still reach the middle slot, while LMMM's dst read (>=32 after its
+   read) must miss it.
+
+3. The YMMM value 36 is not really "36": the measurements only pin the
+   read->write threshold to the range 33..38 (<=32 is too fast on both
+   the sprites-off and screen-off tables, >=39 too slow on sprites-off).
+   That is exactly "strictly more than 32 cycles" — so the underlying
+   value may well be the multiple-of-8 value 32 combined with an
+   exclusive boundary in slot granting (e.g. a request posted exactly at
+   an allocation point missing that slot), rather than a genuine
+   non-multiple-of-8 delay. Possibly the same boundary phenomenon as the
+   LMMM case (32 + something small), which would unify both fixes.
+
+How to validate on real hardware:
+
+- Bus-level capture (the original paper's logic-analyzer setup) of one
+  LMMM in sprites-on mode directly decides between the two explanations
+  in (2): either the middle slots sit at +28 (not +32), or the dst read
+  skips them. Same for YMMM on the sprites-off table (write landing on
+  the pair-second slots 38 cycles after the read).
+- Software-only, out-of-sample tests with vdpcmdx variants (bengalack
+  has NMS-8245, FS-A1, HB-F1XDJ): change the block sizes/widths, use
+  212-line mode, screen 5 instead of 8, other logical ops, 60Hz. The
+  simulator can publish predicted numbers BEFORE the hardware runs;
+  matching predictions on cases not used for calibration is strong
+  validation.
+- More chips: V9958 machines and other V9938 batches, to see whether the
+  behavior is uniform.

--- a/src/video/VDPAccessSlots.cc
+++ b/src/video/VDPAccessSlots.cc
@@ -157,7 +157,7 @@ struct CycleTable : AccessTable
 	{
 		// !!! Keep this in sync with the 'Delta' enum !!!
 		constexpr std::array<int, NUM_DELTAS> delta = {
-			0, 1, 16, 24, 28, 32, 40, 48, 64, 72, 88, 104, 120, 128, 136
+			0, 1, 16, 24, 28, 32, 36, 40, 48, 64, 72, 88, 104, 120, 128, 136
 		};
 
 		size_t out = 0;

--- a/src/video/VDPAccessSlots.hh
+++ b/src/video/VDPAccessSlots.hh
@@ -21,17 +21,18 @@ enum class Delta : int {
 	D24   =  3 * TICKS,
 	D28   =  4 * TICKS,
 	D32   =  5 * TICKS,
-	D40   =  6 * TICKS,
-	D48   =  7 * TICKS,
-	D64   =  8 * TICKS,
-	D72   =  9 * TICKS,
-	D88   = 10 * TICKS,
-	D104  = 11 * TICKS,
-	D120  = 12 * TICKS,
-	D128  = 13 * TICKS,
-	D136  = 14 * TICKS,
+	D36   =  6 * TICKS,
+	D40   =  7 * TICKS,
+	D48   =  8 * TICKS,
+	D64   =  9 * TICKS,
+	D72   = 10 * TICKS,
+	D88   = 11 * TICKS,
+	D104  = 12 * TICKS,
+	D120  = 13 * TICKS,
+	D128  = 14 * TICKS,
+	D136  = 15 * TICKS,
 };
-static constexpr int NUM_DELTAS = 15;
+static constexpr int NUM_DELTAS = 16;
 
 /** VDP-VRAM access slot calculator, meant to be used in the inner loops of the
   * VDPCmdEngine commands. Code optimized for the case that:

--- a/src/video/VDPCmdEngine.cc
+++ b/src/video/VDPCmdEngine.cc
@@ -1122,6 +1122,18 @@ void VDPCmdEngine::executeLmmm(EmuTime limit)
 	unsigned dstAddr = Mode::addressOf(ADX, DY, dstExt);
 	auto calculator = getSlotCalculator(limit);
 
+	// With sprite rendering enabled the destination read cannot use the
+	// access slot 32 cycles after the source read; it only executes 48 or
+	// more cycles later. Grauw's measurements ('64R 32R 24W') did not
+	// cover this case; the '32' only holds when the sprite fetches are
+	// disabled. Derived from and verified against real-hardware
+	// measurements with the 'vdpcmdx' test tool, see issue #2057 and
+	// doc/internal/vdp-cmd-timing-issue2057.md.
+	Delta dstReadDelta =
+		(!vdp.isMSX1VDP() && vdp.getDisplayMode().isBitmapMode() &&
+		 vdp.isDisplayEnabled() && vdp.spritesEnabledRegister())
+		? Delta::D48 : Delta::D32;
+
 	switch (phase) {
 	case 0:
 loop:		if (calculator.limitReached()) [[unlikely]] { phase = 0; break; }
@@ -1130,7 +1142,7 @@ loop:		if (calculator.limitReached()) [[unlikely]] { phase = 0; break; }
 		} else {
 		       tmpSrc = 0xFF;
 		}
-		calculator.next(Delta::D32);
+		calculator.next(dstReadDelta);
 		[[fallthrough]];
 	case 1:
 		if (calculator.limitReached()) [[unlikely]] { phase = 1; break; }

--- a/src/video/VDPCmdEngine.cc
+++ b/src/video/VDPCmdEngine.cc
@@ -1615,7 +1615,7 @@ void VDPCmdEngine::startYmmm(EmuTime time)
 	ADX = DX;
 	ANX = tmpNX;
 	nextAccessSlot(time);
-	calcFinishTime(tmpNX, tmpNY, 24 + 40);
+	calcFinishTime(tmpNX, tmpNY, 36 + 24);
 	phase = 0;
 }
 
@@ -1645,17 +1645,27 @@ loop:		if (calculator.limitReached()) [[unlikely]] { phase = 0; break; }
 			tmpSrc = vram.cmdReadWindow.readNP(
 			       Mode::addressOf(ADX, SY, dstExt));
 		}
-		calculator.next(Delta::D24);
+		// Grauw's paper lists '40 R 24 W' with no per-line overhead,
+		// but that does not match measurements with the 'vdpcmdx' test
+		// tool: with sprites disabled real hardware is ~30% faster
+		// than that model predicts. '36 R->W, 24 W->R, 64 per line'
+		// matches all vdpcmdx measurements (sprites on/off, screen
+		// off, vblank) within 1.5%. On the sprites-enabled slot table
+		// both timings produce the same read cadence, which is likely
+		// why the difference went unnoticed. See issue #2057 and
+		// doc/internal/vdp-cmd-timing-issue2057.md.
+		calculator.next(Delta::D36);
 		[[fallthrough]];
-	case 1:
+	case 1: {
 		if (calculator.limitReached()) [[unlikely]] { phase = 1; break; }
 		if (doPset) [[likely]] {
 			vram.cmdWrite(Mode::addressOf(ADX, DY, dstExt),
 			              tmpSrc, calculator.getTime());
 		}
 		ADX += TX;
+		Delta delta = Delta::D24;
 		if (--ANX == 0) {
-			// note: going to the next line does not take extra time
+			delta = Delta::D88; // 24 + 64
 			SY += TY; DY += TY; --NY;
 			ADX = DX; ANX = tmpNX;
 			if (--tmpNY == 0) {
@@ -1663,13 +1673,14 @@ loop:		if (calculator.limitReached()) [[unlikely]] { phase = 0; break; }
 				break;
 			}
 		}
-		calculator.next(Delta::D40);
+		calculator.next(delta);
 		goto loop;
+	}
 	default:
 		UNREACHABLE;
 	}
 	engineTime = calculator.getTime();
-	calcFinishTime(tmpNX, tmpNY, 24 + 40);
+	calcFinishTime(tmpNX, tmpNY, 36 + 24);
 
 	/*
 	if (dstExt) [[unlikely]] {

--- a/src/video/VDPCmdEngine.cc
+++ b/src/video/VDPCmdEngine.cc
@@ -1124,7 +1124,8 @@ void VDPCmdEngine::executeLmmm(EmuTime limit)
 
 	// With sprite rendering enabled the destination read cannot use the
 	// access slot 32 cycles after the source read; it only executes 48 or
-	// more cycles later. Grauw's measurements ('64R 32R 24W') did not
+	// more cycles later. The timing paper's measurements ('64R 32R 24W',
+	// see doc/internal/vdp-vram-timing/) did not
 	// cover this case; the '32' only holds when the sprite fetches are
 	// disabled. Derived from and verified against real-hardware
 	// measurements with the 'vdpcmdx' test tool, see issue #2057 and
@@ -1645,7 +1646,8 @@ loop:		if (calculator.limitReached()) [[unlikely]] { phase = 0; break; }
 			tmpSrc = vram.cmdReadWindow.readNP(
 			       Mode::addressOf(ADX, SY, dstExt));
 		}
-		// Grauw's paper lists '40 R 24 W' with no per-line overhead,
+		// The VRAM timing paper lists '40 R 24 W' with no per-line
+		// overhead (doc/internal/vdp-vram-timing/),
 		// but that does not match measurements with the 'vdpcmdx' test
 		// tool: with sprites disabled real hardware is ~30% faster
 		// than that model predicts. '36 R->W, 24 W->R, 64 per line'

--- a/src/video/VDPCmdEngine.cc
+++ b/src/video/VDPCmdEngine.cc
@@ -1123,12 +1123,16 @@ void VDPCmdEngine::executeLmmm(EmuTime limit)
 	auto calculator = getSlotCalculator(limit);
 
 	// With sprite rendering enabled the destination read cannot use the
-	// access slot 32 cycles after the source read; it only executes 48 or
-	// more cycles later. The timing paper's measurements ('64R 32R 24W',
-	// see doc/internal/vdp-vram-timing/) did not
-	// cover this case; the '32' only holds when the sprite fetches are
-	// disabled. Derived from and verified against real-hardware
-	// measurements with the 'vdpcmdx' test tool, see issue #2057 and
+	// access slot exactly 32 cycles after the source read; the
+	// measurements constrain the effective minimum spacing to somewhere
+	// in 33..65 cycles (48 chosen). The timing paper's measurements
+	// ('64R 32R 24W', see doc/internal/vdp-vram-timing/) did not cover
+	// this case; the '32' only holds when the sprite fetches are
+	// disabled. An alternative explanation with identical observable
+	// behavior is that the middle slot of each 32/32 slot-triplet sits a
+	// few cycles earlier than in the measured table. Derived from and
+	// verified against real-hardware measurements with the 'vdpcmdx'
+	// test tool, see issue #2057 and
 	// doc/internal/vdp-cmd-timing-issue2057.md.
 	Delta dstReadDelta =
 		(!vdp.isMSX1VDP() && vdp.getDisplayMode().isBitmapMode() &&
@@ -1647,16 +1651,18 @@ loop:		if (calculator.limitReached()) [[unlikely]] { phase = 0; break; }
 			       Mode::addressOf(ADX, SY, dstExt));
 		}
 		// The VRAM timing paper lists '40 R 24 W' with no per-line
-		// overhead (doc/internal/vdp-vram-timing/),
-		// but that does not match measurements with the 'vdpcmdx' test
-		// tool: with sprites disabled real hardware is ~30% faster
-		// than that model predicts. '36 R->W, 24 W->R, 64 per line'
-		// matches all vdpcmdx measurements (sprites on/off, screen
-		// off, vblank) within 1.5%. On the sprites-enabled slot table
-		// both timings produce the same read cadence, which is likely
-		// why the difference went unnoticed. See issue #2057 and
+		// overhead (doc/internal/vdp-vram-timing/), but that does not
+		// match measurements with the 'vdpcmdx' test tool: with
+		// sprites disabled real hardware is ~30% faster than that
+		// model predicts. The measurements constrain the timing to:
+		// R->W unchanged (24), W->R somewhere in 33..38 (36 chosen)
+		// instead of 40, plus a per-line overhead of ~68 cycles. This
+		// fits all 8 non-CPU vdpcmdx measurements within 0.7%. On the
+		// sprites-enabled slot table old and new timing produce the
+		// same cadence, which is likely why the difference went
+		// unnoticed. See issue #2057 and
 		// doc/internal/vdp-cmd-timing-issue2057.md.
-		calculator.next(Delta::D36);
+		calculator.next(Delta::D24);
 		[[fallthrough]];
 	case 1: {
 		if (calculator.limitReached()) [[unlikely]] { phase = 1; break; }
@@ -1665,9 +1671,9 @@ loop:		if (calculator.limitReached()) [[unlikely]] { phase = 0; break; }
 			              tmpSrc, calculator.getTime());
 		}
 		ADX += TX;
-		Delta delta = Delta::D24;
+		Delta delta = Delta::D36;
 		if (--ANX == 0) {
-			delta = Delta::D88; // 24 + 64
+			delta = Delta::D104; // 36 + 68
 			SY += TY; DY += TY; --NY;
 			ADX = DX; ANX = tmpNX;
 			if (--tmpNY == 0) {


### PR DESCRIPTION
Follow-up on #2057. bengalack's new [vdpcmdx](https://github.com/bengalack/vdpcmdx)
tool measures how many pixels each block command processes per frame
(screen 8, 192 lines), separately for VBLANK and the active area, with
sprites on / sprites off / screen off, and with/without concurrent CPU
VRAM access. Comparing openMSX against the real-HW reference numbers
(Sony HB-F1XD) exposed two timing errors in the command engine.

**Method.** An offline simulator of the access-slot model
(`VDPAccessSlots` tables + per-command deltas, added under
`doc/internal/`) reproduces openMSX's own vdpcmdx results within ~0.5%
on all 30 non-CPU measurements. Candidate rules were then fitted
against the real-hardware numbers, implemented, and verified by running
vdpcmdx in the patched emulator.

**LMMM: destination read needs ≥48 cycles after the source read when
sprites are enabled.** With sprites on, openMSX was ~28% too fast
(1717/1699 px per frame vs 1339/1332 real). LMMM is the only measured
command with two back-to-back reads, and only the sprites-on slot table
is affected — sprites-off and screen-off match with the documented 32.
Alternatives are excluded by the data: a slot-index rule ("skip one
slot") gives 1245, and a global 48 breaks sprites-off (1659 vs 1971)
and screen-off (1851 vs 2004). The paper already hints at unexplained
behaviour here (the sprites-on slot at cycle 170 is "rarely actually
used"). After the fix: 1339 vs 1339 and 1333 vs 1332.

**YMMM: the two inter-access values are effectively swapped, and there
is a per-line overhead.** The published '40 R 24 W, no per-line
overhead' made openMSX ~25% too slow with sprites off (2870 vs 3797).
No delta pair with zero line overhead can fit the measurements (best
possible: 19% error). 'read -36-> write -24-> next read, +64 per line'
fits all eight non-CPU YMMM measurements within 1.5%, including the
portrait screen-off and VBLANK cells that were also off. On the
sprites-on table both timings produce the identical read cadence, which
is likely why this was never noticed. Adds `Delta::D36`.

With both changes every non-CPU cell of the vdpcmdx table is within
~1% of real hardware.

**Not addressed: the +CPU columns.** The real-HW numbers there show
exact slot saturation (the OUT loop issues 19 requests/line; in
sprites-on mode every command gets the remaining 31−19 = 12 slots/line
— confirmed for all five commands within 1%). Simulating the paper's
allocation model (slots granted 16 cycles in advance, CPU priority,
request buffers) reproduces this phase-independently, while the current
`stealAccessSlot` approach is phase-fragile (the same build measured
1156 and 970 for HMMM+CPU on different runs; real HW is a stable 1160).
Under the proper allocation model the LMMM 48-cycle rule causes no
+CPU regression, so that rework — essentially the model described in
the VRAM timing paper — is the remaining step; the analysis is in
`doc/internal/vdp-cmd-timing-issue2057.md`.

Both rules are calibrated descriptions of measured behaviour; the
physical mechanism (likely sprite-fetch interaction with the request
pipeline) is unknown. Re-verification on other V9938 machines would be
welcome — vdpcmdx makes that easy.