### PR TITLE
VDP: sprites-on padding from the new captures, and the timing analysis

### DIFF
--- a/doc/internal/vdp-vram-timing/2026-measurement-analysis.md
+++ b/doc/internal/vdp-vram-timing/2026-measurement-analysis.md
@@ -1,0 +1,506 @@
+# V9938 command timing against the 2026 logic-analyzer measurements
+
+In 2026 a second set of logic-analyzer captures of the V9938-VRAM bus was made, on a
+Philips NMS 8280, and published in the `part2` subdirectory of
+<https://github.com/m9710797/vdp-timing-measurements>. Unlike the 2013 set, it covers
+all three access-slot patterns (display off, display on with sprites off, display on
+with sprites on) with roughly equal weight, and it includes captures with the CPU
+accessing VRAM at the same time.
+
+This document fits openMSX's command-engine timing model to that data. It replaces the
+earlier reasoning from the 2013 set plus aggregate `vdpcmdx` frame counts, discussed in
+<https://github.com/openMSX/openMSX/issues/2057> and
+<https://github.com/sndpl/openMSX/pull/5>; the fixes that came out of that discussion
+are commits 592ce968c and 7dde62b3f. Everything section 4 and section 6 describe is
+implemented, in commit 5b0327eaf; the "openMSX today" rows below are measured against
+the state before it.
+
+Two scripts in this directory produce every number here:
+
+```
+vcd-slot-grid.py <measurement-repo>/part2                  # where the slots are
+2026-measurement-check.py <repo>/part2/5.slots             # command timing
+2026-measurement-check.py <repo>/part2/5.slots --cpu       # under CPU contention
+2026-measurement-check.py <repo>/part2/5.slots --plain     # without section 4's rules
+cpu-arbitration-model.py <measurement-repo>                # the CPU's own slots
+```
+
+Cycle numbers throughout are openMSX's, which are based on /RAS. The `.txt` analyses in
+the measurement repository are based on /CAS, which normally follows /RAS by one cycle —
+but not for two slots per table, see section 2.
+
+## 1. The model under test
+
+openMSX implements exactly the model Wouter derived in 2013 (`slots3.txt`):
+
+* VRAM access slots are at fixed positions in a display line; which positions depends
+  on the screen mode and on whether display and sprites are enabled
+  (`VDPAccessSlots.cc`).
+* A slot is allocated ~16 cycles in advance. If a CPU request is pending at that
+  moment the CPU gets the slot; otherwise the command engine gets it if it has a
+  request pending; otherwise the slot goes unused.
+* The engine posts its request for access *k+1* a fixed number of cycles after access
+  *k* completed. That number depends on the command and on which step of the command
+  it is.
+
+openMSX folds the arbitration latency into the per-step number, so one `Delta` value
+per command step covers both:
+
+> next access = the first access slot at or after (previous access + delta)
+
+For a single observed pair of consecutive engine accesses (at *p* and *n*), that model
+holds for every delta in `[prevSlot(n) - p + 1, n - p]`. Intersecting those intervals
+over every observation of one step gives the step's admissible band. An empty band
+means no single value can reproduce the data — the interesting case.
+
+## 2. The access slot tables are confirmed, measured from /RAS
+
+`part2/README.md` proposes moving two slots per table one cycle later. openMSX's tables
+need no change, and the apparent disagreement is a difference of convention, not an
+error on either side — see the end of this section.
+
+The published `.txt` analyses derive access times by interpolating between the eight
+DRAM refresh accesses of a line, which is only eight anchors per line. `/RAS` is a much
+better time base: it pulses once per potential access slot whether or not the VDP uses
+the slot, and its pattern repeats every display line. `vcd-slot-grid.py` in this
+directory measures the grid directly from the raw `part2/1.vcd` captures:
+
+* **Line period.** Exactly one gap per line is larger than all the others, so the sample
+  distance between successive occurrences of it is the line period. Fitted per capture
+  this gives 5131.13 to 5131.18 samples, very stable. (Taken literally that makes a VDP
+  cycle 46.89 ns where 21.477 MHz is 46.57 ns, so the analyser runs about 0.7 % above
+  its nominal 80 MHz, or the machine's crystal is off by that much. It cancels, because
+  everything is normalised by the measured period.)
+* **Numbering.** The refresh accesses are 128 cycles apart with the row address
+  incrementing by one and the bank alternating, and between the last of one line and the
+  first of the next there are 472 cycles, so the chain has a unique start. That one is
+  at cycle 284 — the slot openMSX omits between 276 and 292.
+* **Precision.** Over 40 captures each slot is averaged over at least 249 RAS edges with
+  a standard deviation of at most 0.31 cycles, so each mean is good to ±0.02.
+
+Result:
+
+| mode | slots per line | gap structure | worst deviation of an openMSX slot |
+|---|---|---|---|
+| display off | 166 | 163 × 8 + 2 × 10 + 1 × 44 = 1368 | 0.013 cycles |
+| sprites off | 132 | 6 × 66 + 8 × 29 + 10 × 2 + 12 + 20 × 32 + 24 + 44 = 1368 | 0.025 cycles |
+| sprites on | 126 | irregular (sprite fetches) | 0.055 cycles |
+
+All 154 / 88 / 31 openMSX slots are confirmed. Two further checks that the numbering is
+not off by one: openMSX's display-off table is *exactly* the measured 166-slot grid minus
+the eight refresh slots (284 + 128k) and the four dummy-read slots (1236, 1244, 1252,
+1260), and shifting the anchor by one cycle makes both of those holes stop lining up.
+
+Of the 104 211 accesses in the published `5.slots` files, only 1 108 (1.06 %) sit at a
+cycle that is not a /RAS slot, and they are exactly the two slots of the proposed
+correction (display off CAS 1326 and 1336, sprites off CAS 1324 and 1334; sprites on has
+none). So the retiming is otherwise correct to the cycle, including across the
+1181 → 285 stretch where there are no refresh accesses to interpolate between.
+
+**Why the two conventions disagree there.** /CAS normally follows /RAS by one cycle. For
+exactly those slots it follows by two:
+
+| mode | single-/CAS accesses | with a 1-cycle /RAS → /CAS delay | with 2 cycles |
+|---|---|---|---|
+| display off | 4 862 | 4 839 | 23, all at RAS 1324 and 1334 |
+| sprites off | 4 382 | 4 336 | 46, all at RAS 1322 and 1332 |
+| sprites on | 8 036 | 8 036 | none |
+
+(Burst accesses — one /RAS with several /CAS — are excluded; those are the display
+fetches.) So openMSX's /RAS-based 1324 / 1334 and the measurement repository's /CAS-based
+1326 / 1336 describe the same two slots, and the only wrong assumption was that the
+conversion between them is a uniform one cycle. `2026-measurement-check.py` subtracts two
+rather than one for those slots.
+
+That the extra /CAS delay lands on exactly the two slots that start the 10-cycle gaps is
+not a coincidence: they are the stretched memory cycles of section 4.1.
+
+## 3. Results
+
+508 traces without CPU activity yield 76 766 engine-to-engine transitions. Under the
+plain model — the delay counted in VDP cycles — six steps have no value that fits, and
+the three sprites-on steps in bold are disjoint from the other two modes:
+
+| command | step | display off | sprites off | sprites on |
+|---|---|---|---|---|
+| HMMV | W → W        | [45,48]  | [45,48]  | [33,52]  |
+| HMMV | newline      | [101,104]| [103,104]| [97,116] |
+| LMMV | R → W        | [20,24]  | [21,24]  | [19,26]  |
+| LMMV | W → R        | [69,72]  | [71,72]  | [71,78]  |
+| LMMV | newline      | [133,132]! | [133,132]! | [133,148] |
+| YMMM | R → W        | [20,24]  | [21,24]  | [9,26]   |
+| YMMM | W → R        | [37,40]  | [34,38]  | [33,52]  |
+| YMMM | newline      | [101,104]| [103,104]| [97,118] |
+| HMMM | R → W        | [20,24]  | [21,24]  | [9,26]   |
+| HMMM | W → R        | [61,60]! | [61,60]! | [59,64]  |
+| HMMM | newline      | [125,128]| [129,128]! | **[133,134]** |
+| LMMM | Rsrc → Rdst  | [29,32]  | [28,32]  | **[33,52]** |
+| LMMM | Rdst → W     | [20,24]  | [21,24]  | [9,26]   |
+| LMMM | W → Rsrc     | [61,60]! | [61,60]! | [59,64]  |
+| LMMM | newline      | [125,128]| [129,128]! | **[131,148]** |
+| LINE | R → W        | [18,24]  | [21,24]  | [9,26]   |
+| LINE | W → R        | [85,84]! | [85,84]! | [79,90]  |
+| LINE | newline      | [117,120]| [119,122]| [117,128]|
+
+`!` marks a band that is empty by one cycle. `newline` is the step from the last write
+of one line of the rectangle to the first read of the next. Section 5 shows that all of
+the `!` cases and all three of the bold ones come from two mechanisms, not from noise,
+and that fixing the first collapses the second.
+
+## 4. What the model needs
+
+Two refinements to the plain model account for everything but 32 of the 76 766
+transitions; the third, in section 6, accounts for those.
+
+### 4.1 The delay is counted in memory cycles, not VDP cycles
+
+The measured display-off grid is 8-cycle regular except for two gaps of 10 in the
+blanking region — `... 1316 1324 1334 1344 ...` — i.e. **two memory cycles per line are
+stretched by two cycles each**. Every one of the six `!` bands in section 3 is a pair of
+observations that straddle that stretch differently. The clearest case, HMMM's write →
+read, decoded straight from `scr5-dispOff-hmmm-noCpu-1.vcd` with no interpolation:
+
+```
+  80 R 1bd55    104 W 1fd55    164 R 1bd56      W -> R = +60
+1268 R 1bd62   1292 W 1fd62   1360 R 1bd63      W -> R = +68
+```
+
+From 1292 there *is* a slot at +60 (1352) and the engine skipped it; from 104 the slot at
++60 (164) was taken. The difference is that 1292 → 1352 crosses both stretched memory
+cycles and 104 → 164 crosses neither.
+
+> If the engine's delay counter does not see the stretch — i.e. it counts memory cycles
+> rather than VDP cycles — the conflict disappears. 1292 → 1352 is then 56 engine cycles,
+> so a minimum of 57..60 skips it and takes 1360 (64), while 104 → 164 is 60 either way.
+
+The 44-cycle gap is *not* a stretch: it is five memory cycles that offer no slot, and it
+counts in full, which is what HMMV needs (from 120 a 45..48 minimum skips 164 at +44 and
+takes 172 at +52).
+
+Note the counter has to be read as restarted at every access: the correction loses four
+cycles per line, so it is well defined for an interval but not as a periodic remapping of
+the line. That is exactly how the engine behaves — it is a delay from the previous
+access, not a position in the line.
+
+### 4.2 With sprites on, every delay is one cycle longer
+
+With 4.1 in place, every step becomes internally consistent in every mode, and the three
+steps that still need a sprites-on distinction all need *exactly one cycle more*:
+
+| step | display off / sprites off | sprites on |
+|---|---|---|
+| LMMM Rsrc → Rdst | [27,32] | [33,52] |
+| HMMM newline | [125,128] | [129,134] |
+| LMMM newline | [125,128] | [129,148] |
+
+So one rule replaces the three per-command special cases: **with sprite rendering active
+every command-engine delay is effectively one cycle longer.** It gives the same 32
+mispredictions, and it *forces* LMMM's source→destination read to 32 and the line
+transition to 128 — the values the other two modes already wanted. It reads like the
+arbitration decision for a slot being taken one cycle earlier while the sprite fetch
+logic is active. It cannot be a slot-position effect: shifting the sprites-on slots would
+leave intervals within that mode unchanged.
+
+### 4.3 The resulting values
+
+| command | step | admissible | chosen | openMSX before |
+|---|---|---|---|---|
+| HMMM, LMMM (dst), LMMV, YMMM, LINE | R → W | 21..24 | 24 | 24 |
+| HMMM, LMMM | W → R(src) | 59..60 | **60** | 64 |
+| LMMM | R(src) → R(dst) | 27..32 | **32** | 32, and 48 with sprites on |
+| HMMV | W → W | 45..48 | **46** | 48 |
+| LMMV | W → R | 71..72 | **72** | 72 |
+| YMMM | W → R | 33..38 | **36** | 38 |
+| LINE | W → R | 81..84 | **84** | 88 |
+| HMMV | newline | 103..104 | **104** | 104 |
+| YMMM | newline | 103..104 | **104** | 104 |
+| LINE | newline | 119..120 | **120** | 120 |
+| HMMM, LMMM | newline | 125..128 | **128** | 128, and 134 with sprites on |
+| LMMV | newline | 129..132 | **130** | 134 |
+
+The values in the `chosen` column are Wouter's, picked so that each command has one
+per-line overhead that all of its steps share: HMMV 46 + 58 and 104 = 46 + 58, LMMV
+24 + 72 + 58, YMMM 24 + 36 + 68, HMMM 24 + 60 + 68, LMMM 32 + 24 + 60 + 68, LINE
+24 + 84 + 36. Those constraints have almost no freedom left in them: a shared *even*
+overhead for the two fills forces 58 and with it HMMV 46 and LMMV 72, a shared even
+overhead for the three copies forces 68 and with it YMMM 36 and HMMM/LMMM 60. Only
+R → W ∈ {22, 24} and LINE ∈ {84 + 36, 82 + 38} are left, and both are settled by
+preferring the multiple of 4. The fills and the copies cannot share one overhead --
+[57,59] and [68,69] are disjoint -- and no assignment makes every value a multiple of 8.
+
+| model | mispredicted of 76 766 |
+|---|---|
+| openMSX today | 456 (0.594 %) |
+| 4.1 + 4.2, with the deltas above | 32 (0.042 %) |
+| and section 6 | **0** |
+
+The rules go together: the deltas above *without* 4.1 give 1970 (2.6 %). The same model
+gets the 2013 set right as well -- 3965 transitions, 0 wrong -- once the truncation of
+`screen5screenoffHMMVnocpu.txt` is taken into account.
+
+Both rules are free at run time: they only change how `VDPAccessSlots.cc` builds its
+per-cycle lookup tables — the stretch as a correction inside the table generator, the
+sprites-on cycle as a per-table offset — and they remove the mode conditionals from the
+command implementations entirely. See the `Timing` struct in `VDPAccessSlots.cc`. The character, text and MSX1 tables are left alone, having never
+been measured this way.
+
+`vdpcmdx` improves as well, which it did not have to, since none of this was fitted to
+it. Active area, non-CPU columns, before → after (real hardware in brackets):
+
+| cell | before | after | real |
+|---|---|---|---|
+| HMMM portrait `NO SPR`  | 2636 | **2658** | 2659 |
+| HMMM landscape `NO SPR` | 2668 | **2672** | 2673 |
+| LMMM landscape `NO SPR` | 1970 | **1971** | 1971 |
+| LMMM portrait `NO SPR`  | 1954 | **1955** | 1955 |
+| YMMM landscape `NO SPR` | 3796 | **3797** | 3797 |
+| YMMM landscape `NO SCR` | 3994 | 3995 | 3996 |
+
+Every non-CPU cell is now within 3 pixels of the reference. Nothing else in the non-CPU
+columns changed.
+
+### 4.4 One caveat on 4.2
+
+The stretch is measured in display-off and sprites-off mode; in sprites-on mode the
+signature is not visible, because the sprite fetches occupy that part of the line and
+there is no command or CPU slot there to show the two-cycle /CAS delay. The
+implementation applies the stretch to all three bitmap tables, which is what makes the
+sprites-on cost come out as one cycle.
+
+The alternative — applying it only where it is directly measured — fits the data exactly
+as well (32 mispredictions either way) but then the sprites-on cost is five cycles, and
+LMMM's source→destination read and the line transition come out at 28 and 126 instead of
+the round 32 and 128. Since the stretch is a property of the line timing rather than of
+the sprite fetching, and since the tidier constants fall out of it, the first reading is
+implemented. The data cannot distinguish them.
+
+## 5. History: the parameter-only fix
+
+Superseded by section 4, kept because the `vdpcmdx` comparison below is the only
+end-to-end check of the whole chain. Two of openMSX's values were outside the admissible
+band of the plain model and were corrected first:
+
+| step | was | now | plain-model band |
+|---|---|---|---|
+| YMMM `W → R` | 36 | 38 | [37,38] |
+| LMMV newline | 136 (= 72 + 64) | 134 (= 72 + 62) | [133,134] |
+
+and the sprites-on deviation known from LMMM's destination read applies to the
+line-transition step of both HMMM and LMMM as well, so that step used 134 instead of 128
+when sprite rendering was active. Under section 4 all three become consequences of the
+two table properties rather than separate facts.
+
+`vdpcmdx` barely notices, as expected. Measured on a Philips NMS 8255, the ACTIVE block,
+non-CPU columns, before → after:
+
+| cell | master | patched | real |
+|---|---|---|---|
+| LMMM landscape `NORMAL` | 1340 | **1339** | 1339 |
+| LMMM portrait `NORMAL`  | 1333 | 1331 | 1332 |
+| HMMV landscape `NORMAL` | 4003 | 4002 | 4005 |
+| YMMM portrait `NORMAL`  | 2093 | **2094** | 2095 |
+
+and every other non-CPU cell is unchanged. The line-transition step happens once per
+rectangle line, so it is worth well under a pixel per frame; and shifting the engine by
+one 32-cycle slot at a line transition mostly just moves it to another phase of the same
+128-cycle pattern, at the same throughput. An offline simulation of openMSX's own model
+over the 192-line active window gives the same answer: HMMM ±0, LMMM landscape −1. The
+HMMV and YMMM cells above cannot be affected by any of the three changes, so those two
+±1 differences are cross-talk: `vdpcmdx` runs its tests back to back, so a change in one
+test shifts the phase at which the next one starts. Two runs of the same binary are
+bit-identical, so this is not emulator non-determinism.
+
+The `NORMAL+CPU` column moves by up to 190 pixels in one cell for the same reason,
+amplified: with the CPU taking a slot every 72 cycles the engine's slot selection is
+chaotically sensitive to its starting phase. That column cannot judge this change (nor,
+as Wouter has pointed out, can its hardcoded `REAL` values judge anything at the
+few-percent level).
+
+So the justification for these changes is the bus captures, not the aggregate frame
+counts.
+
+## 6. Slots that follow another slot after only 6 cycles
+
+The sprites-off display area has its slots in pairs 6 cycles apart, at offsets
+{0, 6, 32, 38, 64, 70, 96} of every 128 cycles. Reading the raw captures, the pair is
+the *freed sprite fetch* and the memory cycle that is spare in both modes: with sprites
+on, the cycle at 182 + 32k fetches sprite data and the one at 188 + 32k is free; with
+sprites off, both are free. 25 of the 88 sprites-off slots are the second of such a
+pair. Neither the display-off nor the sprites-on table has any.
+
+Two independent effects follow from that, and both are needed:
+
+**The command engine pays one cycle.** A step whose *previous* access was in one of
+those 25 slots takes one cycle longer, as if that memory cycle -- squeezed against its
+predecessor -- had finished one cycle late. 1778 transitions in the 2026 set start from
+such a slot: 32 of them (HMMM's and LMMM's line transition from cycle 188) need the extra
+cycle, and 1281 of them rule out a third cycle. So the band is exactly [1, 2]; openMSX
+adds 1. Without it those 32 are the only mispredictions left in the whole set.
+
+**The CPU never gets one.** Of 4550 CPU accesses in the sprites-off captures of both
+measurement sets, **zero** are in one of those 25 slots, while all 63 other slots are
+used. That is not a coincidence of the request phase: with the requests arriving 71.5
+cycles apart against a 32-cycle slot pattern, an unconstrained model puts 11 % of them
+there.
+
+What happens instead is visible in the traces. Every unclassified read of `0x1ffff`
+outside the four-slot dummy-read block of a normal line -- 335 of them, in the
+sprites-off CPU captures and nowhere else -- sits in one of those 25 slots and is
+followed by a CPU access in the next slot (322 at +26, 10 at +54). So the VDP *does* give
+the slot to the CPU; it just cannot carry a CPU access, spends the memory cycle on a
+dummy read, and does the access one slot later.
+
+That also explains the last of the engine mispredictions in the CPU captures: the engine
+was not skipping a free slot, the slot was occupied by that dummy read.
+
+## 7. Traces that were mislabelled
+
+`scr5-dispOff-hmmv-noCpu-nx2-6d`, `scr5-dispOff-lmmv-noCpu-nx2-3d`,
+`scr5-dispOff-ymmm-noCpu-nx12-1d`, `scr5-sprOff-lmmm-noCpu-nx2-3d` and
+`scr5-sprOff-lmmv-noCpu-nx8-5d` were named `noCpu` but contained CPU accesses. Before
+excluding them they were the *only* source of inconsistency in the middle of a display
+line -- every other anomaly is at the blanking boundary or is the sprites-on effect of
+section 4.2. They have since been fixed or renamed to `scr5-wrong-*` in the measurement
+repository, and the `d` sets have been relabelled.
+
+Two accesses in the CPU captures still carry the wrong code, and they are the only
+remaining mispredictions of the engine model there:
+
+* `scr5-sprOn-hmmm-rdCpu-1.txt` has no `R.r` at all: the CPU's reads (0x1849a upwards)
+  are coded `R.s`, together with the command's own source reads (0x1a1c2 upwards).
+* `scr5-sprOn-hmmv-wrCpu-3.txt` has one `R.s 19e91` at cycle 4452 which belongs to the
+  CPU's write sequence (…19e90, 19e91, 19e92…) -- HMMV has no source read.
+
+One labelling subtlety is not a mistake: the unclassified read of `0x1ffff` is the VDP's
+dummy read in most traces, but in a few YMMM captures the command's own source pointer
+walks through the top of VRAM and produces genuine command accesses at that address. The
+check script distinguishes the two by looking at the rest of the trace.
+
+## 8. The CPU side
+
+### 8.1 The engine model under contention
+
+The `rdCpu` / `wrCpu` traces give 12 302 engine transitions with CPU accesses about 71.5
+cycles apart, and the CPU takes the slot the engine wanted in **30 %** of them. Applying
+openMSX's rule
+
+> the engine takes the first slot at or after its minimum that the CPU did not take
+> (`VDPCmdEngine::stealAccessSlot`)
+
+to the observed CPU access times:
+
+| | wrong |
+|---|---|
+| openMSX today | 90 (0.732 %) |
+| the model of sections 4 and 6 | **3 (0.024 %)** |
+| the same, but the loser re-arms its full delay instead of taking the next slot | 3086 (25.1 %) |
+
+and the remaining 3 are the two mislabelled accesses of section 7. So `stealAccessSlot`
+is right, including the detail that a command engine which loses a slot takes the *next*
+slot rather than re-arming its full delay. The hypothesis floated earlier in
+[sndpl/openMSX#5](https://github.com/sndpl/openMSX/pull/5) -- that under contention real
+hardware uses slots closer together than the command's own minimum spacing -- is
+refuted.
+
+### 8.2 The CPU's own model
+
+`cpu-arbitration-model.py` fits the other half: which slot a CPU port access ends up in.
+The two measurement sets are complementary. The 2013 machine (NMS 8250) has a single
+clock, so the port accesses sit on an exact grid -- 40 of them 72 cycles apart, then 252
+cycles of loop overhead -- with one unknown phase per capture. The 2026 machine (NMS
+8280) has separate CPU and VDP clocks, but /CSR and /CSW were recorded, so the pace of
+the port accesses is measurable.
+
+The model:
+
+1. The request register is one deep and is occupied from the port access until about 9
+   cycles before the VRAM access. A port access arriving while it is occupied is **lost**
+   -- no VRAM access happens for it, and the VDP's VRAM pointer does not advance, so the
+   CPU sees the previous byte again. openMSX models this (`VDP::scheduleCpuVramAccess`,
+   `tooFastCallback`); what the measurements add is that the *old* request wins, which is
+   also what openMSX does, and the 9 cycles.
+2. 27 cycles before each slot the VDP decides who gets it; the CPU wins over the command
+   engine. Like the engine's delays this is counted in the VDP's memory cycles -- but only
+   partly: of the 4 cycles the two stretched memory cycles add, the engine's delay absorbs
+   all 4 and the CPU's lead absorbs **1, 2 or 3**. 0 and 4 are both excluded, each by
+   observations in a different capture.
+3. A slot that follows another slot after 6 cycles is decided 2 cycles earlier still, and
+   carries the dummy read of section 6 instead of the CPU's access.
+
+Fit:
+
+| set | CPU accesses | not predicted | predicted but absent |
+|---|---|---|---|
+| 2013, exact grid, one phase per capture | 1141 | **0** | **0** |
+| 2026, fitted pace, one offset per capture | 12843 | 143 (1.11 %) | 120 |
+
+For the 2026 set the requests are not taken from the individual /CSx edges but from a
+straight line fitted through the whole capture: the Z80's own crystal makes the port
+accesses a perfectly regular sequence in Z80 time (12 T-states apart inside a burst, 42
+from one burst to the next), and one line through ~115 of them has a residual of 0.15
+cycles, well under the analyzer's 0.27-cycle sampling step. The fitted rate is
+**5.96113 ± 0.00004 VDP cycles per Z80 T-state**, i.e. 71.5336 cycles between port
+accesses where a single-clock machine would give exactly 6 and 72 -- the Z80 of that
+NMS 8280 runs 0.65 % fast relative to its VDP.
+
+The VDP can only act on an asynchronous /CSx at one of its own clock edges, so the
+request times are rounded up to whole VDP cycles. That is worth something: 143
+mispredictions with the rounding, 165 without, 168 if the rounding is to 2 cycles and 833
+if it is to 4. So the VDP samples /CSx on a 1-cycle grid.
+
+Per mode, with the fitted per-capture offset (`LEAD` + offset is the lead from the rising
+edge of /CSx to the slot):
+
+| mode | accesses | not predicted | lost requests | lead |
+|---|---|---|---|---|
+| display off | 4793 | 54 (1.13 %) | 0 of 4848 | 25.84 ± 0.13 |
+| sprites off | 4346 | 23 (0.53 %) | 12 of 4385 | 25.85 ± 0.14 |
+| sprites on | 3703 | 66 (1.78 %) | 301 of 4023 | **27.92 ± 0.64** |
+
+Two things stand out. The offset is reproducible to ±0.14 cycles over 80 captures, which
+is a good check on the whole chain. And sprites-on wants a lead 2 cycles longer -- the
+same direction as the command engine's extra cycle in that mode (section 4.2), and the
+same 2 cycles as the 6-cycle-pair slots want.
+
+The lost requests are why the 2026 captures show 8 % more /CSx pulses than VRAM accesses
+in sprites-on mode, where the slots are up to 70 cycles apart, and none in display-off
+mode, where they are 8 apart.
+
+## 9. What would help next
+
+* **The sprites-on cycle.** Section 4.2 is a uniform rule fitted to three steps. A
+  software-only test that would strengthen it: time HMMM's line transition (a rectangle
+  one byte wide and many lines tall, so the transition dominates the whole command) in
+  sprites-on mode against LMMV's `W -> R` and HMMV's `W -> W` in the same mode, and check
+  that the one-cycle difference shows up where the model says it should.
+* **The blanking stretch.** Section 4.1 predicts that a command started at a phase where
+  its next access would land just after the stretch behaves four cycles differently from
+  one that does not cross it. A phase-resolved completion-time measurement -- sync to the
+  line interrupt, burn a programmable number of cycles, start a one- or two-pixel
+  command, then poll S#2 once -- resolves a single command's finish time to about six
+  cycles and would test that directly.
+* **Command startup cost.** Still never measured. It is invisible to `vdpcmdx` (one
+  command per frame of 10240 pixels). `part2` contains three `*-start-*` captures that
+  reach step 4 but not `5.slots`; without knowing what the capture was triggered on they
+  cannot be turned into a number, but if that is recoverable they would be the first
+  direct measurement of it.
+* **A slower CPU loop.** The sprites-on lead (section 8.2) is 2 cycles longer than the
+  other two modes but with 5x the scatter, because that is the mode where requests are
+  lost and each loss blurs the fit. One `IN A,(#98)` every few hundred cycles would
+  remove the losses and pin the lead down in all three modes.
+* **Alternating read and write.** Nothing in either set can tell whether a read and a
+  write have the same lead: each capture is all reads or all writes, so any difference
+  disappears into the fitted phase. A loop that alternates them would separate the two.
+
+## 10. Where the stretched memory cycles might come from
+
+Speculation, with no measurements behind it. The V9938 data book documents bits S0 and
+S1 of R#9 as selecting one of three "cycle modes", and its tables give 1368 cycles per
+horizontal line for S1,S0 = 0,0 but 1365 for the other two settings (section 5 "Cycle
+mode" and section 7-1 "Horizontal display parameters"). A VDP that has to be able to
+drop three cycles from a line has some reason to keep a subsystem from counting a few
+cycles in the blanking region, which is what section 4.1 measures — 4 cycles rather than
+3, and openMSX does not implement the 1365-cycle modes at all, so this is a hint at most.
+
+Data book: <https://www.mirrorservice.org/sites/www.bitsavers.org/pdf/yamaha/Yamaha_V9938_MSX-Video_Technical_Data_Book_Aug85.pdf>,
+transcription: <https://map.grauw.nl/resources/video/v9938/v9938.xhtml>.

--- a/doc/internal/vdp-vram-timing/2026-measurement-analysis.md
+++ b/doc/internal/vdp-vram-timing/2026-measurement-analysis.md
@@ -182,24 +182,20 @@ cycles per line, so it is well defined for an interval but not as a periodic rem
 the line. That is exactly how the engine behaves — it is a delay from the previous
 access, not a position in the line.
 
-### 4.2 With sprites on, every delay is one cycle longer
+### 4.2 With sprites on, every delay is two cycles longer
 
-With 4.1 in place, every step becomes internally consistent in every mode, and the three
-steps that still need a sprites-on distinction all need *exactly one cycle more*:
+With 4.1 in place, every step becomes internally consistent in every mode, and the steps
+that still need a sprites-on distinction all need the *same* extra amount. So one rule
+replaces the three per-command special cases: **with sprite rendering active every
+command-engine delay is two cycles longer.** It reads like the arbitration decision for a
+slot being taken two cycles earlier while the sprite fetch logic is active — the CPU
+arbitration wants a similar amount (section 8.2). It cannot be a slot-position effect:
+shifting the sprites-on slots would leave intervals within that mode unchanged.
 
-| step | display off / sprites off | sprites on |
-|---|---|---|
-| LMMM Rsrc → Rdst | [27,32] | [33,52] |
-| HMMM newline | [125,128] | [129,134] |
-| LMMM newline | [125,128] | [129,148] |
-
-So one rule replaces the three per-command special cases: **with sprite rendering active
-every command-engine delay is effectively one cycle longer.** It gives the same 32
-mispredictions, and it *forces* LMMM's source→destination read to 32 and the line
-transition to 128 — the values the other two modes already wanted. It reads like the
-arbitration decision for a slot being taken one cycle earlier while the sprite fetch
-logic is active. It cannot be a slot-position effect: shifting the sprites-on slots would
-leave intervals within that mode unchanged.
+The size of this depends on how much padding sprites-on mode has in the blanking region,
+which is why section 4.4 had to be settled first: with the padding measured directly the
+answer is two cycles, and LMMM's source→destination read and the line transition come out
+at the round 32 and 128 that the other two modes already want.
 
 ### 4.3 The resulting values
 
@@ -259,20 +255,26 @@ it. Active area, non-CPU columns, before → after (real hardware in brackets):
 Every non-CPU cell is now within 3 pixels of the reference. Nothing else in the non-CPU
 columns changed.
 
-### 4.4 One caveat on 4.2
+### 4.4 Where the padding is, per mode
 
-The stretch is measured in display-off and sprites-off mode; in sprites-on mode the
-signature is not visible, because the sprite fetches occupy that part of the line and
-there is no command or CPU slot there to show the two-cycle /CAS delay. The
-implementation applies the stretch to all three bitmap tables, which is what makes the
-sprites-on cost come out as one cycle.
+The stretch of 4.1 is the VDP padding its line out to 1368 cycles. Measured from /RAS over
+the whole blanking region, not just the slots the command engine can use, the three
+bitmap modes do it differently:
 
-The alternative — applying it only where it is directly measured — fits the data exactly
-as well (32 mispredictions either way) but then the sprites-on cost is five cycles, and
-LMMM's source→destination read and the line transition come out at 28 and 126 instead of
-the round 32 and 128. Since the stretch is a property of the line timing rather than of
-the sprite fetching, and since the tidier constants fall out of it, the first reading is
-implemented. The data cannot distinguish them.
+| mode | ordinary spacing there | padded cycles | total |
+|---|---|---|---|
+| display off | 8 | two of 10, at 1324→1334→1344 | +4 |
+| sprites off | 8 | two of 10, at 1322→1332→1342 | +4 |
+| sprites on | 13, 6, 10 repeating | three of 15, 7, 11, at 1315→1330→1337→1348 | +3 |
+
+The sprites-on row was guesswork until the `s16`/`s32`/`s48` captures arrived, because in
+that mode the padded cycles are sprite fetches rather than command slots. Section 10 shows
+how those captures settle it.
+
+Getting it right matters: with the sprites-on padding assumed to be +4 like the other two
+modes, the sprites-on cost of 4.2 comes out as one cycle instead of two, and the fit is
+equally good. Both were consistent with the command traces; the direct measurement is what
+separates them.
 
 ## 5. History: the parameter-only fix
 
@@ -406,101 +408,133 @@ refuted.
 
 `cpu-arbitration-model.py` fits the other half: which slot a CPU port access ends up in.
 The two measurement sets are complementary. The 2013 machine (NMS 8250) has a single
-clock, so the port accesses sit on an exact grid -- 40 of them 72 cycles apart, then 252
-cycles of loop overhead -- with one unknown phase per capture. The 2026 machine (NMS
-8280) has separate CPU and VDP clocks, but /CSR and /CSW were recorded, so the pace of
-the port accesses is measurable.
+clock, so the port accesses sit on an exact grid with one unknown phase per capture. The
+2026 machine (NMS 8280) has separate CPU and VDP clocks, but /CSR and /CSW were recorded,
+so the pace of the port accesses is measurable.
 
 The model:
 
-1. The request register is one deep and is occupied from the port access until about 9
-   cycles before the VRAM access. A port access arriving while it is occupied is **lost**
-   -- no VRAM access happens for it, and the VDP's VRAM pointer does not advance, so the
-   CPU sees the previous byte again. openMSX models this (`VDP::scheduleCpuVramAccess`,
-   `tooFastCallback`); what the measurements add is that the *old* request wins, which is
-   also what openMSX does, and the 9 cycles.
-2. 27 cycles before each slot the VDP decides who gets it; the CPU wins over the command
-   engine. Like the engine's delays this is counted in the VDP's memory cycles -- but only
-   partly: of the 4 cycles the two stretched memory cycles add, the engine's delay absorbs
-   all 4 and the CPU's lead absorbs **1, 2 or 3**. 0 and 4 are both excluded, each by
-   observations in a different capture.
-3. A slot that follows another slot after 6 cycles is decided 2 cycles earlier still, and
-   carries the dummy read of section 6 instead of the CPU's access.
+1. **A constant delay** between the port access and the moment the arbiter sees the
+   request. This is wall-clock time -- it is a pin-to-register delay, not something the
+   memory sequencer counts -- and it is not separable from the fitted phase, so it is
+   simply absorbed into it.
+2. **A lookahead of 16 memory cycles at the arbiter.** The CPU gets the first eligible
+   slot at least that far away, counted in the VDP's memory cycles with exactly the same
+   padding subtraction as the command engine's delays.
+3. **One request register.** A port access arriving while it is occupied is lost -- no
+   VRAM access happens for it, and the VDP's VRAM pointer does not advance, so the CPU
+   sees the previous byte again. It stays occupied until 2 cycles after the access.
+   openMSX models this (`VDP::scheduleCpuVramAccess`, `tooFastCallback`); what the
+   measurements add is that the *old* request wins, which is also what openMSX does.
+4. A slot that follows another slot after 6 cycles is decided 2 cycles earlier than the
+   rest, and carries the dummy read of section 6 instead of the CPU's access.
+
+The 2013 set constrains the lookahead and the dead window only through their sum: any
+(lookahead, dead window) with lookahead + dead = 18 and lookahead ≤ 16 fits it exactly.
+16 + 2 is the top of that band and matches the 16 cycles openMSX already uses
+(`Delta::CPU_16`).
 
 Fit:
 
 | set | CPU accesses | not predicted | predicted but absent |
 |---|---|---|---|
 | 2013, exact grid, one phase per capture | 1141 | **0** | **0** |
-| 2026, fitted pace, one offset per capture | 12843 | 143 (1.11 %) | 120 |
+| 2026, fitted pace, one offset per capture | 14766 | 121 (0.82 %) | 116 |
 
 For the 2026 set the requests are not taken from the individual /CSx edges but from a
 straight line fitted through the whole capture: the Z80's own crystal makes the port
-accesses a perfectly regular sequence in Z80 time (12 T-states apart inside a burst, 42
-from one burst to the next), and one line through ~115 of them has a residual of 0.15
-cycles, well under the analyzer's 0.27-cycle sampling step. The fitted rate is
-**5.96113 ± 0.00004 VDP cycles per Z80 T-state**, i.e. 71.5336 cycles between port
-accesses where a single-clock machine would give exactly 6 and 72 -- the Z80 of that
-NMS 8280 runs 0.65 % fast relative to its VDP.
+accesses a perfectly regular sequence in Z80 time, and one line through ~115 of them has
+a residual of 0.15 cycles, well under the analyzer's 0.27-cycle sampling step. The fitted
+rate is **5.96113 ± 0.00004 VDP cycles per Z80 T-state**, where a single-clock machine
+would give exactly 6 -- the Z80 of that NMS 8280 runs 0.65 % fast relative to its VDP.
+Two different test programs (40 port accesses 12 T-states apart, and 20 of them 37
+T-states apart) give the same rate to 1 part in 10^5.
 
 The VDP can only act on an asynchronous /CSx at one of its own clock edges, so the
 request times are rounded up to whole VDP cycles. That is worth something: 143
 mispredictions with the rounding, 165 without, 168 if the rounding is to 2 cycles and 833
-if it is to 4. So the VDP samples /CSx on a 1-cycle grid.
+if it is to 4 (measured before the model was changed to the split form above, but the
+ordering is what matters). So the VDP samples /CSx on a 1-cycle grid.
 
-Per mode, with the fitted per-capture offset (`LEAD` + offset is the lead from the rising
-edge of /CSx to the slot):
+Per pace and mode, with the constant of point 1 fitted per capture:
 
-| mode | accesses | not predicted | lost requests | lead |
-|---|---|---|---|---|
-| display off | 4793 | 54 (1.13 %) | 0 of 4848 | 25.84 ± 0.13 |
-| sprites off | 4346 | 23 (0.53 %) | 12 of 4385 | 25.85 ± 0.14 |
-| sprites on | 3703 | 66 (1.78 %) | 301 of 4023 | **27.92 ± 0.64** |
+| pace | mode | accesses | not predicted | lost requests | constant |
+|---|---|---|---|---|---|
+| 72 | display off | 4793 | 43 (0.90 %) | 0 of 4848 | 9.85 ± 0.12 |
+| 72 | sprites off | 4346 | 16 (0.37 %) | 12 of 4385 | 9.84 ± 0.11 |
+| 72 | sprites on | 3703 | 59 (1.59 %) | 304 of 4022 | 12.10 ± 2.01 |
+| 222 | display off | 675 | 1 (0.15 %) | 0 of 685 | 9.75 ± 0.22 |
+| 222 | sprites off | 608 | **0** | 0 of 610 | 9.72 ± 0.30 |
+| 222 | sprites on | 641 | 2 (0.31 %) | 0 of 646 | 10.61 ± 1.18 |
 
-Two things stand out. The offset is reproducible to ±0.14 cycles over 80 captures, which
-is a good check on the whole chain. And sprites-on wants a lead 2 cycles longer -- the
-same direction as the command engine's extra cycle in that mode (section 4.2), and the
-same 2 cycles as the 6-cycle-pair slots want.
+The 222-cycle captures are the ones with a slow CPU loop, made specifically to remove the
+lost requests, and they do: 3 of 1924 accesses mispredicted, and one whole mode exact.
+The constant repeats to ±0.01 cycles between display-off and sprites-off and to ±0.15
+between the two paces, which is a good check on the whole chain -- the analyzer time
+base, the slot grid, the pace fit and the model. Sprites-on wants 1 to 2 cycles more, in
+the same direction as the command engine's two extra cycles in that mode, but with a much
+larger scatter because that mode has the fewest slots per line.
 
-The lost requests are why the 2026 captures show 8 % more /CSx pulses than VRAM accesses
-in sprites-on mode, where the slots are up to 70 cycles apart, and none in display-off
-mode, where they are 8 apart.
+Of the 121 that are left, 21 are the *first* access of their capture, which is 15 times
+the rate the remaining positions show. That is the one thing the model cannot know: a
+capture starts at an arbitrary point in the test program, so there may already be a
+request in flight. 107 of the other 112 are isolated single slots.
 
 ## 9. What would help next
 
-* **The sprites-on cycle.** Section 4.2 is a uniform rule fitted to three steps. A
-  software-only test that would strengthen it: time HMMM's line transition (a rectangle
-  one byte wide and many lines tall, so the transition dominates the whole command) in
-  sprites-on mode against LMMV's `W -> R` and HMMV's `W -> W` in the same mode, and check
-  that the one-cycle difference shows up where the model says it should.
-* **The blanking stretch.** Section 4.1 predicts that a command started at a phase where
-  its next access would land just after the stretch behaves four cycles differently from
-  one that does not cross it. A phase-resolved completion-time measurement -- sync to the
-  line interrupt, burn a programmable number of cycles, start a one- or two-pixel
-  command, then poll S#2 once -- resolves a single command's finish time to about six
-  cycles and would test that directly.
 * **Command startup cost.** Still never measured. It is invisible to `vdpcmdx` (one
   command per frame of 10240 pixels). `part2` contains three `*-start-*` captures that
   reach step 4 but not `5.slots`; without knowing what the capture was triggered on they
   cannot be turned into a number, but if that is recoverable they would be the first
-  direct measurement of it.
-* **A slower CPU loop.** The sprites-on lead (section 8.2) is 2 cycles longer than the
-  other two modes but with 5x the scatter, because that is the mode where requests are
-  lost and each loss blurs the fit. One `IN A,(#98)` every few hundred cycles would
-  remove the losses and pin the lead down in all three modes.
+  direct measurement of it. Otherwise: sync to the line interrupt, burn a programmable
+  number of cycles, start a one- or two-pixel command, poll S#2 once. The same rig would
+  test section 4.1 directly, since it predicts that a command whose next access lands
+  just after the padding behaves differently from one that does not cross it.
 * **Alternating read and write.** Nothing in either set can tell whether a read and a
-  write have the same lead: each capture is all reads or all writes, so any difference
-  disappears into the fitted phase. A loop that alternates them would separate the two.
+  write reach the arbiter with the same delay: each capture is all reads or all writes,
+  so any difference disappears into the fitted constant. A loop that alternates them
+  would separate the two.
+* **Sprites-on with a slow loop and more slots.** The sprites-on constant of section 8.2
+  is still the loosest number in the model (±1.2 cycles even at the slow pace), simply
+  because that mode has 31 slots per line. Splitting the lookahead from the constant
+  delay -- the two are only separable where the padding falls inside the lookahead window
+  -- would need captures with requests deliberately placed near cycle 1330.
+* **The 1365-cycle modes.** Section 10 measures the line length and where the padding
+  goes, but openMSX does not implement those modes at all. If it ever does, the
+  prediction is that the command engine needs no padding correction there.
 
-## 10. Where the stretched memory cycles might come from
+## 10. Where the padding comes from: R#9 S1/S0, measured
 
-Speculation, with no measurements behind it. The V9938 data book documents bits S0 and
-S1 of R#9 as selecting one of three "cycle modes", and its tables give 1368 cycles per
-horizontal line for S1,S0 = 0,0 but 1365 for the other two settings (section 5 "Cycle
-mode" and section 7-1 "Horizontal display parameters"). A VDP that has to be able to
-drop three cycles from a line has some reason to keep a subsystem from counting a few
-cycles in the blanking region, which is what section 4.1 measures — 4 cycles rather than
-3, and openMSX does not implement the 1365-cycle modes at all, so this is a hint at most.
+The V9938 data book documents bits S1 and S0 of R#9 as selecting one of three "cycle
+modes", and gives 1368 cycles per horizontal line for S1,S0 = 0,0 but 1365 for the other
+two settings (section 5 "Cycle mode" and section 7-1 "Horizontal display parameters").
+The `scr5-sprOn-hmmv-noCpu-s{0,16,32,48}-*e.vcd` captures test that directly. Taking the
+line period and the refresh interval both in analyzer samples, so that nothing has to be
+assumed about either, the line comes out as 128 x period / refresh:
+
+| R#9 | line length |
+|---|---|
+| s = 0 | 1368.01 ± 0.04 |
+| s = 16 | 1364.94 ± 0.12 |
+| s = 32 | 1364.94 ± 0.09 |
+| s = 48 | 1365.01 ± 0.10 |
+
+So 1368 and 1365 exactly, as documented. And the three cycles come off precisely where
+section 4.1 says the padding is: in sprites-on mode the blanking region runs
+
+```
+S1,S0 = 0,0 :  ... 13   6  10   6  10   6  13  [15   7  11]  6  10   6  13  13   6 ...
+otherwise   :  ... 13   6  10   6  10   6  13  [14   6  10]  6  10   6  13  13   6 ...
+```
+
+— the same grid with three memory cycles one cycle shorter, which is the 1365-cycle line
+plus the padding. Everything else in the line is unchanged, and the horizontal
+set-adjust captures (`adjust0` … `adjust15`) leave the line at 1368.02 ± 0.03 in all five
+settings, as expected.
+
+That confirms the mechanism behind section 4.1: the padding is real, it sits in the
+blanking region, and the command engine's delay counter does not see it. It also fixes
+the amount per mode, which section 4.4 could not do from the command traces alone.
 
 Data book: <https://www.mirrorservice.org/sites/www.bitsavers.org/pdf/yamaha/Yamaha_V9938_MSX-Video_Technical_Data_Book_Aug85.pdf>,
 transcription: <https://map.grauw.nl/resources/video/v9938/v9938.xhtml>.

--- a/doc/internal/vdp-vram-timing/2026-measurement-check.py
+++ b/doc/internal/vdp-vram-timing/2026-measurement-check.py
@@ -115,10 +115,17 @@ RELABEL = {'dispOff': {1325: 1324, 1335: 1334},
            'sprOff': {1323: 1322, 1333: 1332},
            'sprOn': {}}
 
-# The two stretched memory cycles: the slot between the two stretches, and the
-# first slot after them.
+# The VDP pads its line out to 1368 cycles by making a few memory cycles in the
+# horizontal blanking region longer than the rest.  Measured from /RAS, and
+# confirmed by the R#9 S1/S0 captures, where the padding disappears and the line
+# is 1365 cycles: display off and sprites off get two cycles of 10 where the
+# rest of that part of the line runs at 8, sprites on gets three cycles one
+# cycle longer than the 14/6/10 pattern it would otherwise have.  Each entry is
+# the cycle at which one stretch has completed; STRETCH_STEP is how many cycles
+# each of them adds.
 STRETCH = {'dispOff': (1334, 1344), 'sprOff': (1332, 1342),
-           'sprOn': (1332, 1342)}
+           'sprOn': (1330, 1337, 1348)}
+STRETCH_STEP = {'dispOff': 2, 'sprOff': 2, 'sprOn': 1}
 
 # VRAM accesses per pixel/byte step, and the role of each
 ROLES = {
@@ -159,6 +166,9 @@ FITTED = {
 # table has them, 25 of its 88.
 TIGHT = {m: {s for s in t if (s - 6) in set(t)} for m, t in TABLES.items()}
 
+# Cycles that sprite rendering adds to every command engine step.
+SPR_ON_EXTRA = 2
+
 PLAIN = [False]     # --plain: VDP cycles, and no sprites-on adjustment
 TIGHT_RULE = [True]  # the extra cycle after an access in a 6-cycle-pair slot
 PUBLISHED = [False]  # --published-slots: use part2/README.md's slot correction
@@ -174,8 +184,9 @@ def V(mode, t):
     if PLAIN[0]:
         return t
     line, c = divmod(t, TICKS)
-    a, b = STRETCH[mode]
-    return t - (4 * line + (0 if c < a else 2 if c < b else 4))
+    step = STRETCH_STEP[mode]
+    seen = sum(1 for a in STRETCH[mode] if c >= a)
+    return t - step * (len(STRETCH[mode]) * line + seen)
 
 
 def meta(path):
@@ -284,7 +295,7 @@ def delta_for(table, spron, key, mode, prev=None):
     if mode == 'sprOn':
         if key in spron:
             return spron[key]
-        return table[key] + (0 if PLAIN[0] else 1)
+        return table[key] + (0 if PLAIN[0] else SPR_ON_EXTRA)
     return table[key]
 
 
@@ -388,7 +399,7 @@ def main():
             a, z = b[k]
             cells.append(f'[{a},{z}]' + ('!' if a > z else ''))
             if mode == 'sprOn' and not args.plain:
-                a, z = a - 1, z - 1     # sprites-on costs one cycle more
+                a, z = a - SPR_ON_EXTRA, z - SPR_ON_EXTRA
             lo, hi = max(lo, a), min(hi, z)
         allb = f'[{lo},{hi}]' + ('   no single value' if lo > hi else '')
         print(f'{cmd:5} {step:9} ' + ' '.join(f'{c:>12}' for c in cells)

--- a/doc/internal/vdp-vram-timing/2026-measurement-check.py
+++ b/doc/internal/vdp-vram-timing/2026-measurement-check.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Fit the openMSX command-engine timing model to the 2026 logic-analyzer set.
+
+Usage:
+    2026-measurement-check.py <measurement-repo>/part2/5.slots [--cpu] [--plain]
+
+Reads the annotated access traces from
+<https://github.com/m9710797/vdp-timing-measurements> and, for every
+command-engine step (e.g. HMMM's write -> next read), reports which delays
+would reproduce *every* observed access.
+
+The model is openMSX's:
+
+    next access = the first VRAM access slot at or after (previous access +
+                  delta), where delta = 'command engine work' + 'request
+                  arbitration latency'
+
+with two refinements that the raw captures force (see
+2026-measurement-analysis.md; vcd-slot-grid.py does the slot measurement):
+
+  * the delay is counted in the VDP's memory cycles rather than VDP cycles.
+    Two memory cycles per line are stretched by two cycles each in the
+    horizontal blanking region -- the slot grid there runs
+    ... 1316 1324 1334 1344 ... where every other gap is 8 -- and the engine's
+    counter does not see the stretch.  '--plain' turns this off.
+  * with sprite rendering active every delay is one cycle longer.
+
+For one observed pair (previous access at p, next access at n) the model is
+satisfied by every delta in [prevSlot(n) - p + 1, n - p] measured in that time
+base; intersecting over all observations of a step gives its band.
+
+Cycle numbers here are openMSX's, which are based on /RAS.  The .txt files of
+the measurement repository are based on /CAS and are one higher.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import glob
+import os
+import re
+import sys
+
+TICKS = 1368                # VDP cycles per display line
+DUMMY_CODE, DUMMY_ADDR = 'R..', 0x1FFFF   # the VDP's dummy read
+CPU_CODES = ('R.r', 'W.w')  # CPU read / write
+VRAM_LINE = 128             # bytes per VRAM line in screen 5
+
+# --------------------------------------------------------------------------
+# Access slot tables, exactly as in src/video/VDPAccessSlots.cc.
+#
+# Measured from /RAS in the raw captures: all 154 / 88 / 31 slots are confirmed
+# to within 0.06 cycles.
+#
+# The .txt analyses in the measurement repository are /CAS based.  /CAS normally
+# follows /RAS by one cycle, but for exactly two slots per table -- 1324 and
+# 1334 here, 1322 and 1332 for sprites-off -- it follows by two, because those
+# two memory cycles are stretched (see V() below).  So the CAS -> RAS conversion
+# is not a uniform -1 for those two slots; RELABEL handles them.
+# --------------------------------------------------------------------------
+SLOTS_DISP_OFF = [
+       0,    8,   16,   24,   32,   40,   48,   56,   64,   72,
+      80,   88,   96,  104,  112,  120,  164,  172,  180,  188,
+     196,  204,  212,  220,  228,  236,  244,  252,  260,  268,
+     276,  292,  300,  308,  316,  324,  332,  340,  348,  356,
+     364,  372,  380,  388,  396,  404,  420,  428,  436,  444,
+     452,  460,  468,  476,  484,  492,  500,  508,  516,  524,
+     532,  548,  556,  564,  572,  580,  588,  596,  604,  612,
+     620,  628,  636,  644,  652,  660,  676,  684,  692,  700,
+     708,  716,  724,  732,  740,  748,  756,  764,  772,  780,
+     788,  804,  812,  820,  828,  836,  844,  852,  860,  868,
+     876,  884,  892,  900,  908,  916,  932,  940,  948,  956,
+     964,  972,  980,  988,  996, 1004, 1012, 1020, 1028, 1036,
+    1044, 1060, 1068, 1076, 1084, 1092, 1100, 1108, 1116, 1124,
+    1132, 1140, 1148, 1156, 1164, 1172, 1188, 1196, 1204, 1212,
+    1220, 1228, 1268, 1276, 1284, 1292, 1300, 1308, 1316, 1324,
+    1334, 1344, 1352, 1360,
+]
+SLOTS_SPR_OFF = [
+       6,   14,   22,   30,   38,   46,   54,   62,   70,   78,
+      86,   94,  102,  110,  118,  162,  170,  182,  188,  214,
+     220,  246,  252,  278,  310,  316,  342,  348,  374,  380,
+     406,  438,  444,  470,  476,  502,  508,  534,  566,  572,
+     598,  604,  630,  636,  662,  694,  700,  726,  732,  758,
+     764,  790,  822,  828,  854,  860,  886,  892,  918,  950,
+     956,  982,  988, 1014, 1020, 1046, 1078, 1084, 1110, 1116,
+    1142, 1148, 1174, 1206, 1212, 1266, 1274, 1282, 1290, 1298,
+    1306, 1314, 1322, 1332, 1342, 1350, 1358, 1366,
+]
+SLOTS_SPR_ON = [
+      28,   92,  162,  170,  188,  220,  252,  316,  348,  380,
+     444,  476,  508,  572,  604,  636,  700,  732,  764,  828,
+     860,  892,  956,  988, 1020, 1084, 1116, 1148, 1212, 1264,
+    1330,
+]
+TABLES = {'dispOff': SLOTS_DISP_OFF, 'sprOff': SLOTS_SPR_OFF,
+          'sprOn': SLOTS_SPR_ON}
+
+# part2/README.md's proposed correction, for comparison (--published-slots)
+PUBLISHED_TABLES = {
+    'dispOff': [1325 if s == 1324 else 1335 if s == 1334 else s
+                for s in SLOTS_DISP_OFF],
+    'sprOff': [1323 if s == 1322 else 1333 if s == 1332 else s
+               for s in SLOTS_SPR_OFF],
+    'sprOn': SLOTS_SPR_ON,
+}
+
+
+def table(mode):
+    return (PUBLISHED_TABLES if PUBLISHED[0] else TABLES)[mode]
+
+# CAS -> RAS is -2 rather than -1 for these (after the uniform -1, subtract
+# one more)
+RELABEL = {'dispOff': {1325: 1324, 1335: 1334},
+           'sprOff': {1323: 1322, 1333: 1332},
+           'sprOn': {}}
+
+# The two stretched memory cycles: the slot between the two stretches, and the
+# first slot after them.
+STRETCH = {'dispOff': (1334, 1344), 'sprOff': (1332, 1342),
+           'sprOn': (1332, 1342)}
+
+# VRAM accesses per pixel/byte step, and the role of each
+ROLES = {
+    'hmmv': ('W',),
+    'lmmv': ('R', 'W'),
+    'ymmm': ('R', 'W'),
+    'hmmm': ('R', 'W'),
+    'line': ('R', 'W'),
+    'lmmm': ('Rs', 'Rd', 'W'),
+}
+
+# The values openMSX uses today, for comparison
+OPENMSX = {
+    ('hmmv', 'W->W'): 48,  ('hmmv', 'newline'): 104,
+    ('lmmv', 'R->W'): 24,  ('lmmv', 'W->R'): 72,  ('lmmv', 'newline'): 134,
+    ('ymmm', 'R->W'): 24,  ('ymmm', 'W->R'): 38,  ('ymmm', 'newline'): 104,
+    ('hmmm', 'R->W'): 24,  ('hmmm', 'W->R'): 64,  ('hmmm', 'newline'): 128,
+    ('lmmm', 'Rd->W'): 24, ('lmmm', 'Rs->Rd'): 32, ('lmmm', 'W->Rs'): 64,
+    ('lmmm', 'newline'): 128,
+    ('line', 'R->W'): 24,  ('line', 'W->R'): 88,  ('line', 'newline'): 120,
+}
+OPENMSX_SPR_ON = {('lmmm', 'Rs->Rd'): 48, ('hmmm', 'newline'): 134,
+                  ('lmmm', 'newline'): 134}
+
+# Best fit under the refined model: one value per step, +1 with sprites on,
+# +1 when the previous access was in a slot only 6 cycles after another slot
+FITTED = {
+    ('hmmv', 'W->W'): 46,  ('hmmv', 'newline'): 104,
+    ('lmmv', 'R->W'): 24,  ('lmmv', 'W->R'): 72,  ('lmmv', 'newline'): 130,
+    ('ymmm', 'R->W'): 24,  ('ymmm', 'W->R'): 36,  ('ymmm', 'newline'): 104,
+    ('hmmm', 'R->W'): 24,  ('hmmm', 'W->R'): 60,  ('hmmm', 'newline'): 128,
+    ('lmmm', 'Rd->W'): 24, ('lmmm', 'Rs->Rd'): 32, ('lmmm', 'W->Rs'): 60,
+    ('lmmm', 'newline'): 128,
+    ('line', 'R->W'): 24,  ('line', 'W->R'): 84,  ('line', 'newline'): 120,
+}
+
+# Slots that follow another slot after only 6 cycles.  Only the sprites-off
+# table has them, 25 of its 88.
+TIGHT = {m: {s for s in t if (s - 6) in set(t)} for m, t in TABLES.items()}
+
+PLAIN = [False]     # --plain: VDP cycles, and no sprites-on adjustment
+TIGHT_RULE = [True]  # the extra cycle after an access in a 6-cycle-pair slot
+PUBLISHED = [False]  # --published-slots: use part2/README.md's slot correction
+
+
+def V(mode, t):
+    """The engine's own time: absolute cycle minus the stretch seen so far.
+
+    Deliberately not periodic -- it loses 4 cycles per line -- which is fine
+    because the engine's counter restarts at every access, so only intervals
+    matter.
+    """
+    if PLAIN[0]:
+        return t
+    line, c = divmod(t, TICKS)
+    a, b = STRETCH[mode]
+    return t - (4 * line + (0 if c < a else 2 if c < b else 4))
+
+
+def meta(path):
+    m = re.match(r'scr5-(\w+)-(\w+)-(\w+?)(?:-nx\d+)?-\d+[a-z]?\.txt$',
+                 os.path.basename(path))
+    if not m or m[1] not in TABLES:
+        return None
+    return {'mode': m[1], 'cmd': m[2], 'cpu': m[3],
+            'name': os.path.basename(path)}
+
+
+def parse(path):
+    """[(absolute cycle, code, address)] in time order, RAS numbering.
+
+    The files have one row per cycle-within-a-line and one column per display
+    line, so the absolute CAS cycle is 1368 * column + row, and RAS is one
+    lower.
+    """
+    rel = {} if PUBLISHED[0] else RELABEL[meta(path)['mode']]
+    items = []
+    with open(path) as f:
+        for ln in f:
+            if ':' not in ln:
+                continue
+            row, rest = ln.rstrip('\n').split(':', 1)
+            t = int(row)
+            col = 0
+            while rest:
+                cell = rest[2:13]
+                if cell.strip():
+                    line, c = divmod(TICKS * col + t - 1, TICKS)
+                    items.append((line * TICKS + rel.get(c, c),
+                                  cell[0:3], int(cell[6:11], 16)))
+                rest = rest[13:]
+                col += 1
+    items.sort()
+    return items
+
+
+def transitions(path):
+    """Yield (step, prev cycle, next cycle) for one trace."""
+    info = meta(path)
+    if info is None or info['cmd'] not in ROLES:
+        return
+    roles = ROLES[info['cmd']]
+    acc = [a for a in parse(path) if a[1] not in CPU_CODES]
+    # The dummy read shows up as an unclassified read of 0x1ffff, but in a few
+    # YMMM captures the command's own source pointer walks through the top of
+    # VRAM, so only drop it when nothing else in the trace is near.
+    real = any(a[2] != DUMMY_ADDR and abs(a[2] - DUMMY_ADDR) < 0x400
+               for a in acc)
+    eng = [a for a in acc if real or (a[1], a[2]) != (DUMMY_CODE, DUMMY_ADDR)]
+    writes = [i for i, a in enumerate(eng) if a[1][0] == 'W']
+    groups = []
+    for a, b in zip(writes, writes[1:]):
+        grp = eng[a + 1:b + 1]
+        if len(grp) == len(roles) and \
+                tuple(x[1][0] for x in grp) == tuple(r[0] for r in roles):
+            groups.append(grp)
+    for gi, grp in enumerate(groups):
+        for i in range(len(grp) - 1):
+            yield f'{roles[i]}->{roles[i + 1]}', grp[i][0], grp[i + 1][0]
+        if gi + 1 < len(groups):
+            nxt = groups[gi + 1]
+            if (nxt[-1][2] // VRAM_LINE) == (grp[-1][2] // VRAM_LINE):
+                yield f'{roles[-1]}->{roles[0]}', grp[-1][0], nxt[0][0]
+            elif 0 < nxt[-1][2] - grp[-1][2] <= 2 * VRAM_LINE:
+                yield 'newline', grp[-1][0], nxt[0][0]
+            # else: the command restarted, no useful constraint
+
+
+def next_slot(mode, p, delta, taken=frozenset()):
+    """First slot at least 'delta' engine cycles after p and not taken by the
+    CPU (which has priority)."""
+    tab = table(mode)
+    line = p // TICKS
+    for k in range(4):
+        for s in tab:
+            t = (line + k) * TICKS + s
+            if t > p and V(mode, t) - V(mode, p) >= delta and t not in taken:
+                return t
+    raise AssertionError('no slot found')
+
+
+def prev_slot(mode, n):
+    tab = table(mode)
+    line, off = divmod(n, TICKS)
+    earlier = [s for s in tab if s < off]
+    return (line * TICKS + earlier[-1] if earlier
+            else (line - 1) * TICKS + tab[-1])
+
+
+def delta_for(table, spron, key, mode, prev=None):
+    """Delay for one command step.
+
+    A step that starts from a slot which itself follows another slot after only
+    6 cycles takes one cycle longer -- as if that memory cycle, squeezed against
+    its predecessor, finished one cycle late.  Such slots exist only in the
+    sprites-off table (25 of its 88), which is why the effect shows up in that
+    mode alone.  1778 transitions in the 2026 set start from one; the rule is
+    needed by 32 of them and, at +3 or more, contradicted by 1281.
+    """
+    if (TIGHT_RULE[0] and prev is not None and
+            (prev % TICKS) in TIGHT[mode] and not PLAIN[0]):
+        return delta_for(table, spron, key, mode) + 1
+    if mode == 'sprOn':
+        if key in spron:
+            return spron[key]
+        return table[key] + (0 if PLAIN[0] else 1)
+    return table[key]
+
+
+def bands(files):
+    out = collections.defaultdict(lambda: (1, 400))
+    n = collections.Counter()
+    for f in files:
+        mode = meta(f)['mode']
+        cmd = meta(f)['cmd']
+        for step, p, nx in transitions(f):
+            key = (cmd, step, mode)
+            lo = V(mode, prev_slot(mode, nx)) - V(mode, p) + 1
+            hi = V(mode, nx) - V(mode, p)
+            a, b = out[key]
+            out[key] = (max(a, lo), min(b, hi))
+            n[key] += 1
+    return out, n
+
+
+def count_misses(files, table, spron, cpu_traces=False, plain=None):
+    saved = PLAIN[0]
+    if plain is not None:
+        PLAIN[0] = plain
+    tot = bad = contended = 0
+    per = collections.Counter()
+    for f in files:
+        info = meta(f)
+        # The CPU takes slots away from the engine.  So does the dummy read
+        # the VDP does when the CPU's request wins a 6-cycle-pair slot: it
+        # cannot carry the CPU access, so that memory cycle is spent on a read
+        # of 0x1ffff and the CPU's access happens in the next slot.
+        taken = {a[0] for a in parse(f)
+                 if a[1] in CPU_CODES
+                 or ((a[1], a[2]) == (DUMMY_CODE, DUMMY_ADDR)
+                     and (a[0] % TICKS) in TIGHT[info['mode']])} \
+            if cpu_traces else frozenset()
+        for step, p, nx in transitions(f):
+            key = (info['cmd'], step)
+            d = delta_for(table, spron, key, info['mode'], p)
+            first = next_slot(info['mode'], p, d)
+            got = next_slot(info['mode'], p, d, taken)
+            tot += 1
+            contended += (got != first)
+            if got != nx:
+                bad += 1
+                per[key + (info['mode'],)] += 1
+    PLAIN[0] = saved
+    return tot, bad, contended, per
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('slots_dir')
+    ap.add_argument('--cpu', action='store_true',
+                    help='use the rdCpu/wrCpu traces and test the arbitration')
+    ap.add_argument('--plain', action='store_true',
+                    help='no memory-cycle stretch and no sprites-on +1')
+    ap.add_argument('--published-slots', action='store_true',
+                    help="use part2/README.md's one-cycle slot correction")
+    ap.add_argument('--no-tight', action='store_true',
+                    help='drop the extra cycle after a 6-cycle-pair slot')
+    args = ap.parse_args()
+    PLAIN[0] = args.plain
+    PUBLISHED[0] = args.published_slots
+    TIGHT_RULE[0] = not args.no_tight
+
+    files = [f for f in sorted(glob.glob(os.path.join(args.slots_dir,
+                                                      'scr5-*.txt')))
+             if meta(f) and '-wrong-' not in f]
+    files = [f for f in files
+             if (meta(f)['cpu'] != 'noCpu') == bool(args.cpu)]
+    if not files:
+        sys.exit(f'no traces found in {args.slots_dir}')
+
+    if args.cpu:
+        for label, tbl, spron, pl in (
+                ('openMSX today', OPENMSX, OPENMSX_SPR_ON, True),
+                ('fitted model', FITTED, {}, False)):
+            tot, bad, cont, _ = count_misses(files, tbl, spron, True, pl)
+            print(f'{len(files)} traces with CPU activity, {tot} engine '
+                  f'transitions, the CPU took the slot the engine wanted in '
+                  f'{100.0 * cont / tot:.1f}% of them')
+            print(f'    {label:16}: {bad} mispredicted '
+                  f'({100.0 * bad / tot:.3f}%)')
+        return
+
+    b, n = bands(files)
+    print(f'{len(files)} traces, {sum(n.values())} engine-to-engine transitions'
+          + ('   [--plain: VDP cycles]' if args.plain else ''))
+    print()
+    print(f'{"cmd":5} {"step":9} {"dispOff":>12} {"sprOff":>12} {"sprOn":>12}'
+          f'   all modes')
+    print('-' * 72)
+    for cmd, step in sorted({(k[0], k[1]) for k in b}):
+        cells, lo, hi = [], 1, 400
+        for mode in ('dispOff', 'sprOff', 'sprOn'):
+            k = (cmd, step, mode)
+            if k not in b:
+                cells.append('-')
+                continue
+            a, z = b[k]
+            cells.append(f'[{a},{z}]' + ('!' if a > z else ''))
+            if mode == 'sprOn' and not args.plain:
+                a, z = a - 1, z - 1     # sprites-on costs one cycle more
+            lo, hi = max(lo, a), min(hi, z)
+        allb = f'[{lo},{hi}]' + ('   no single value' if lo > hi else '')
+        print(f'{cmd:5} {step:9} ' + ' '.join(f'{c:>12}' for c in cells)
+              + f'   {allb}')
+    print()
+    for label, tbl, spron, pl in (
+            ('openMSX today', OPENMSX, OPENMSX_SPR_ON, True),
+            ('fitted model', FITTED, {}, args.plain)):
+        tot, bad, _, per = count_misses(files, tbl, spron, plain=pl)
+        print(f'{label:16}: {bad} of {tot} mispredicted '
+              f'({100.0 * bad / tot:.3f}%)')
+        for k, v in sorted(per.items(), key=lambda kv: -kv[1])[:4]:
+            print(f'    {k[0]:5} {k[1]:9} {k[2]:8} {v}')
+
+
+if __name__ == '__main__':
+    main()

--- a/doc/internal/vdp-vram-timing/cpu-arbitration-model.py
+++ b/doc/internal/vdp-vram-timing/cpu-arbitration-model.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""A model of how the V9938 hands VRAM access slots to the CPU, and its fit.
+
+Usage:
+    cpu-arbitration-model.py <measurement-repo>            # both sets
+    cpu-arbitration-model.py <measurement-repo> --2013     # only the old set
+    cpu-arbitration-model.py <measurement-repo> --2026     # only the new set
+
+The model (all times in VDP cycles):
+
+  1. The CPU's request register is one deep.  It is loaded by a port access to
+     #98 and stays occupied until the VRAM access has taken place -- not until
+     the slot has been granted.  A port access that arrives while the register
+     is occupied is lost: no VRAM access happens for it (and the VDP's VRAM
+     pointer does not advance, so the CPU sees the previous byte again).
+
+  2. LEAD cycles before every access slot, the VDP decides who gets it.  A
+     pending CPU request wins; otherwise the command engine gets it if it has a
+     request ready; otherwise the slot goes unused.  LEAD is counted in the
+     VDP's *memory cycles*: the two memory cycles per line that are stretched by
+     two cycles each in the horizontal blanking region do not count towards it,
+     exactly as for the command engine's delays.
+
+  3. A slot that has another slot only 6 cycles before it cannot carry a CPU
+     access.  Such slots exist only in the sprites-off table (25 of the 88), and
+     when the CPU's request wins one, the VDP spends that memory cycle on a dummy
+     read of 0x1FFFF and the CPU's access happens in the next slot.  The decision
+     point of these slots is two cycles earlier than the uniform rule.
+
+What the two measurement sets contribute:
+
+  * 2013 (Philips NMS8250): the CPU clock is exactly VDP/6, so the port accesses
+    sit on an exact grid -- 40 of them 72 cycles apart, then 252 cycles for the
+    loop overhead.  The phase of that grid relative to the VDP is unknown and is
+    fitted per capture; a constant delay between the port access and the
+    arbitration is indistinguishable from it.
+  * 2026 (Philips NMS8280): the two clocks are asynchronous, but /CSR and /CSW
+    were recorded, so the port accesses are known individually.  What is fitted
+    per capture is then only the constant offset, and LEAD becomes measurable:
+    26 cycles from the rising edge of /CSx.
+
+Both sets are scored in both directions: accesses that happened but are not
+predicted, and accesses that are predicted but did not happen.
+"""
+from __future__ import annotations
+
+import argparse
+import bisect
+import math
+import collections
+import glob
+import importlib.util
+import os
+import re
+import statistics
+import sys
+
+TICKS = 1368
+LEAD = 27                # cycles, from the rising edge of /CSx
+PAIR_EXTRA_LEAD = 2      # extra lead of a slot 6 cycles after another slot
+# The register frees this many cycles before the access, not at the access
+# itself: fitted on the 2013 set, where 9 is the unique optimum (7-8 and 10-11
+# are each worse by a handful), and confirmed on the 2026 set, where it predicts
+# 314 lost requests in sprites-on mode against about 326 observed.
+FREE_BEFORE = [9]
+PERIOD_2013 = 3060       # 39 * 72 + 252
+IN_PERIOD = 72
+BURST = 40
+
+_here = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load(name, mod):
+    spec = importlib.util.spec_from_file_location(mod,
+                                                  os.path.join(_here, name))
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+C = _load('2026-measurement-check.py', 'check')
+G = _load('vcd-slot-grid.py', 'grid')
+
+TABLES = C.TABLES
+PAIR = {m: {s for s in TABLES[m] if (s - 6) in set(TABLES[m])} for m in TABLES}
+
+
+# --------------------------------------------------------------------------
+# the model
+# --------------------------------------------------------------------------
+def V(mode, t):
+    """Memory-cycle time: real time minus the blanking stretch seen so far."""
+    line, c = divmod(int(t) if t == int(t) else t // 1, TICKS)
+    line, c = divmod(t, TICKS)
+    a, b = C.STRETCH[mode]
+    return t - (4 * line + (0 if c < a else 2 if c < b else 4))
+
+
+# How many of the 4 stretch cycles per line the CPU's lead absorbs.  The
+# command engine's delays absorb all 4; the CPU's lead absorbs 1, 2 or 3 (each
+# fits the 2013 set exactly, 0 and 4 do not).
+CPU_STRETCH = [2]
+
+
+def decision(mode, s):
+    """Real time at which slot s is handed out."""
+    lead = LEAD + (PAIR_EXTRA_LEAD if (s % TICKS) in PAIR[mode] else 0)
+    base = s - lead
+    want = V(mode, s) - lead
+    t = base
+    while V(mode, t) > want:
+        t -= 1
+    while V(mode, t + 1) <= want:
+        t += 1
+    return base - ((base - t) * CPU_STRETCH[0]) // 4
+
+
+def slots(mode, lo, hi):
+    tab = TABLES[mode]
+    out = []
+    line = lo // TICKS - 1
+    while line * TICKS <= hi:
+        out += [line * TICKS + s for s in tab if lo <= line * TICKS + s <= hi]
+        line += 1
+    return sorted(out)
+
+
+def simulate(mode, requests, lo, hi, drop=True):
+    """(cpu accesses, dummy reads, lost requests).
+
+    'drop' selects what happens when a port access arrives while the register is
+    still occupied: True loses the new one (what the measurements show), False
+    overwrites and loses the old one (what openMSX assumes).
+    """
+    ss = slots(mode, lo - 200, hi + 200)
+    nxt = {s: n for s, n in zip(ss, ss[1:])}
+    # 0 = access completes, 1 = port access, 2 = slot is handed out.  A port
+    # access that lands exactly on a decision point still wins the slot, i.e.
+    # the lead is a shade under 26 rather than exactly 26; five accesses in the
+    # 2013 set say so, and the 2026 measurement of it is 25.98 +- 0.11.
+    ev = ([(s - FREE_BEFORE[0], 0, s) for s in ss]
+          + [(r, 1, r) for r in requests]
+          + [(decision(mode, s), 2, s) for s in ss])
+    ev.sort()
+    busy = False            # register holds a request that has not been served
+    pending = False         # ... and it has not been given a slot yet
+    at = None               # slot in which its access will happen
+    cpu, dummy, lost = [], [], 0
+    for t, kind, val in ev:
+        if kind == 1:
+            if busy:
+                lost += 1
+                if not drop:
+                    pending, at = True, None
+            else:
+                busy, pending, at = True, True, None
+        elif kind == 2:
+            if pending and at is None:
+                if (val % TICKS) in PAIR[mode]:
+                    dummy.append(val)
+                    at = nxt.get(val)
+                else:
+                    at = val
+                pending = False
+        elif at == val:
+            cpu.append(val)
+            busy, at = False, None
+        elif at is None and not pending:
+            pass
+    return cpu, dummy, lost
+
+
+# --------------------------------------------------------------------------
+# the 2013 set: exact request grid, unknown phase
+# --------------------------------------------------------------------------
+CMDS = ('HMMM', 'HMMV', 'LMMM', 'LMMV', 'YMMM', 'HYMM', 'LINE')
+
+
+def meta13(path):
+    b = os.path.basename(path)[:-4]
+    if not b.startswith('screen') or 'wrong' in b:
+        return None
+    scr = re.match(r'screen(\d+)', b)
+    if scr is None or scr[1] not in ('5', '6', '7', '8'):
+        return None
+    mode = ('dispOff' if 'screenoff' in b else
+            'sprOff' if 'nosprites' in b else
+            'sprOn' if 'sprite' in b else None)
+    cpu = ('rd' if 'cpuread' in b else 'wr' if 'cpuwrite' in b else None)
+    if mode is None or cpu is None:
+        return None
+    return {'mode': mode, 'name': b,
+            'cmd': next((c for c in CMDS if c in b), None)}
+
+
+def parse13(path, mode):
+    rel = C.RELABEL[mode]
+    out = []
+    with open(path) as f:
+        for ln in f:
+            if ':' not in ln:
+                continue
+            row, rest = ln.rstrip('\n').split(':', 1)
+            t, col = int(row), 0
+            while rest:
+                cell = rest[2:13]
+                if cell.strip():
+                    line, c = divmod(TICKS * col + t - 1, TICKS)
+                    out.append((line * TICKS + rel.get(c, c), cell[0:3],
+                                int(cell[6:11], 16)))
+                rest = rest[13:]
+                col += 1
+    return sorted(out)
+
+
+def requests13(phase, lo, hi):
+    out = []
+    n = (lo - phase) // PERIOD_2013 - 1
+    while phase + n * PERIOD_2013 <= hi:
+        base = phase + n * PERIOD_2013
+        out += [base + j * IN_PERIOD for j in range(BURST)
+                if lo <= base + j * IN_PERIOD <= hi]
+        n += 1
+    return sorted(out)
+
+
+def run2013(repo, drop=True):
+    print('=== 2013, Philips NMS8250: CPU clock exactly VDP/6 ===')
+    print(f'{"capture":42} {"mode":8} {"n":>4} {"missed":>7} {"spurious":>9} '
+          f'{"lost":>5} {"phases":>7}')
+    tot = collections.Counter()
+    for path in sorted(glob.glob(os.path.join(repo, '8.final-analysis',
+                                              'screen*.txt'))):
+        m = meta13(path)
+        if m is None:
+            continue
+        acc = parse13(path, m['mode'])
+        obs = sorted(t for t, code, a in acc if code in ('R.c', 'W.c'))
+        if len(obs) < 10:
+            continue
+        lo, hi = obs[0] - 100, obs[-1] + 100
+        best = None
+        for phase in range(PERIOD_2013):
+            cpu, dummy, lost = simulate(m['mode'], requests13(phase, lo, hi),
+                                        lo, hi, drop)
+            p = {x for x in cpu if obs[0] <= x <= obs[-1]}
+            miss, extra = len(set(obs) - p), len(p - set(obs))
+            score = (miss + extra, )
+            if best is None or score < best[0]:
+                best = (score, miss, extra, lost, [phase])
+            elif score == best[0]:
+                best[4].append(phase)
+        _, miss, extra, lost, phases = best
+        tot['n'] += len(obs)
+        tot['miss'] += miss
+        tot['extra'] += extra
+        print(f'{m["name"]:42} {m["mode"]:8} {len(obs):4} {miss:7} {extra:9} '
+              f'{lost:5} {len(phases):7}')
+    print(f'\n{tot["n"]} CPU accesses: {tot["miss"]} not predicted '
+          f'({100.0 * tot["miss"] / tot["n"]:.2f}%), {tot["extra"]} predicted '
+          f'but absent\n')
+
+
+# --------------------------------------------------------------------------
+# the 2026 set: /CSx recorded, asynchronous clock
+# --------------------------------------------------------------------------
+def timebase(ref, cyc, anchor):
+    """Anchors from the refresh chain, which is exactly 128 cycles apart."""
+    out = []
+    for t in sorted(ref):
+        c = (t - anchor) * cyc + G.REFRESH_CYCLE
+        line, off = divmod(c, TICKS)
+        k = round((off - G.REFRESH_CYCLE) / 128)
+        if 0 <= k <= 7:
+            exact = line * TICKS + G.REFRESH_CYCLE + 128 * k
+            if abs(exact - c) <= 3:
+                out.append((t, exact))
+    return out
+
+
+def decode26(vcd, rng):
+    trace = G.parse_vcd(vcd)
+    edges = G.ras_edges(trace)
+    g = G.geometry(edges)
+    if g is None:
+        return None
+    period, _ = g
+    cyc = TICKS / period
+    acc = G.accesses(trace)
+    anchor, ref = G.refresh_chain_start(acc, cyc)
+    if anchor is None:
+        return None
+    fixed = timebase(ref, cyc, anchor)
+    if len(fixed) < 4:
+        return None
+    xs = [t for t, _ in fixed]
+    ys = [c for _, c in fixed]
+
+    def cycle(t):
+        i = bisect.bisect_left(xs, t)
+        if i == 0:
+            return ys[0] + (t - xs[0]) * cyc
+        if i >= len(xs):
+            return ys[-1] + (t - xs[-1]) * cyc
+        f = (t - xs[i - 1]) / (xs[i] - xs[i - 1])
+        return ys[i - 1] + f * (ys[i] - ys[i - 1])
+
+    req, prev = [], {'CSR': None, 'CSW': None}
+    for t, s in trace:
+        for sig in ('CSR', 'CSW'):
+            if prev[sig] == 0 and s[sig] == 1:
+                req.append(cycle(t))
+            prev[sig] = s[sig]
+    by = collections.defaultdict(list)
+    for cas, ras, addr, rd in acc:
+        by[ras].append(addr)
+    cpu, dummy = [], []
+    for ras, addrs in sorted(by.items()):
+        if len(addrs) != 1 or ras in ref:
+            continue
+        if addrs[0] == 0x1FFFF:
+            dummy.append(cycle(ras))
+        elif rng[0] <= addrs[0] <= rng[1]:
+            cpu.append(cycle(ras))
+    return sorted(req), sorted(cpu), sorted(dummy)
+
+
+def snap(mode, t):
+    line, off = divmod(t, TICKS)
+    return min(((line + k) * TICKS + s for k in (-1, 0, 1)
+                for s in TABLES[mode]), key=lambda v: abs(v - t))
+
+
+def fit_pace(req):
+    """(cycles per Z80 T-state, phase, residual rms, T-state indices, pulses).
+
+    The port accesses are 12 T-states apart inside the burst of 40 IN/OUT
+    instructions and 42 from the last of one burst to the first of the next.
+    Fitting one straight line through the whole capture recovers the sequence
+    far more accurately than the individual /CSx edges do -- the residuals come
+    out at ~0.15 cycles, well under the analyzer's 0.27-cycle sampling step.
+    A capture occasionally holds a stray pulse, so outliers are rejected.
+    """
+    # two /CSx edges a few cycles apart cannot both be port accesses
+    req = [r for i, r in enumerate(req) if i == 0 or r - req[i - 1] > 40]
+    g = [b - a for a, b in zip(req, req[1:])]
+    s0 = statistics.median([x for x in g if 60 < x < 85]) / 12
+    x = [0]
+    for gap in g:
+        x.append(x[-1] + (42 if 240 < gap < 262
+                          else 12 * max(1, round(gap / (12 * s0)))))
+    keep = list(range(len(req)))
+    s, phi, rms = s0, 0.0, 0.0
+    for _ in range(4):
+        n = len(keep)
+        mx = sum(x[i] for i in keep) / n
+        my = sum(req[i] for i in keep) / n
+        sxx = sum((x[i] - mx) ** 2 for i in keep)
+        sxy = sum((x[i] - mx) * (req[i] - my) for i in keep)
+        s = sxy / sxx
+        phi = my - s * mx
+        res = [req[i] - (phi + s * x[i]) for i in keep]
+        rms = (sum(e * e for e in res) / n) ** 0.5
+        nk = [i for i, e in zip(keep, res) if abs(e) <= max(0.4, 3 * rms)]
+        if len(nk) == len(keep) or len(nk) < 20:
+            break
+        keep = nk
+    return s, phi, rms, x, req
+
+
+def run2026(repo, drop=True, quantum=1):
+    print('=== 2026, Philips NMS8280: CPU clock asynchronous to the VDP ===')
+    vcd_dir = os.path.join(repo, 'part2', '1.vcd')
+    txt_dir = os.path.join(repo, 'part2', '5.slots')
+    agg = collections.defaultdict(collections.Counter)
+    offs = collections.defaultdict(list)
+    rates, rmss = [], []
+    for vcd in sorted(glob.glob(os.path.join(vcd_dir, 'scr5-*.vcd'))):
+        name = os.path.basename(vcd)[:-4]
+        if 'noCpu' in name:
+            continue
+        txt = os.path.join(txt_dir, name + '.txt')
+        if not os.path.exists(txt) or C.meta(txt) is None:
+            continue
+        mode = C.meta(txt)['mode']
+        v = [a for t, code, a in C.parse(txt) if code in C.CPU_CODES]
+        if not v:
+            continue
+        d = decode26(vcd, (min(v), max(v)))
+        if d is None:
+            continue
+        req, cpu, dummy = d
+        obs = sorted({snap(mode, t) for t in cpu})
+        if len(obs) < 10:
+            continue
+        obsd = {snap(mode, t) for t in dummy
+                if (snap(mode, t) % TICKS) in PAIR[mode]}
+        s, phi, rms, xs, _ = fit_pace(req)
+        rates.append(s)
+        rmss.append(rms)
+        base = [phi + s * a for a in xs]
+        lo, hi = obs[0] - 100, obs[-1] + 100
+        best = None
+        o = -6.0
+        while o < 6.0:
+            # the VDP can only see a request at one of its own clock edges
+            rq = [(quantum * math.ceil((b + o) / quantum) if quantum
+                   else b + o) for b in base if lo - 150 < b + o < hi]
+            p, pd, lost = simulate(mode, rq, lo, hi, drop)
+            ps = {x for x in p if obs[0] <= x <= obs[-1]}
+            pds = {x for x in pd if obs[0] <= x <= obs[-1]}
+            score = (len(set(obs) - ps) + len(ps - set(obs))
+                     + len(obsd - pds) + len(pds - obsd))
+            if best is None or score < best[0]:
+                best = (score, o, ps, pds, lost, len(rq))
+            o += 0.05
+        _, off, ps, pds, lost, nreq = best
+        k = agg[mode]
+        k['n'] += len(obs)
+        k['miss'] += len(set(obs) - ps)
+        k['extra'] += len(ps - set(obs))
+        k['dn'] += len(obsd)
+        k['dmiss'] += len(obsd - pds)
+        k['dextra'] += len(pds - obsd)
+        k['lost'] += lost
+        k['req'] += nreq
+        k['cap'] += 1
+        offs[mode].append(off)
+    print(f'pace: {statistics.fmean(rates):.5f} +- {statistics.stdev(rates):.5f}'
+          f' VDP cycles per Z80 T-state ({12 * statistics.fmean(rates):.4f} '
+          f'cycles between port accesses; 6 and 72 on a single-clock machine), '
+          f'fit residual {statistics.median(rmss):.3f} cycles')
+    print(f'requests quantised to {quantum} VDP cycle(s)'
+          if quantum else 'requests not quantised')
+    print(f'{"mode":8} {"cap":>4} {"accesses":>9} {"missed":>7} '
+          f'{"spurious":>9} {"dummy":>6} {"d-miss":>7} {"lost/req":>10} '
+          f'{"offset":>13}')
+    for mode in ('dispOff', 'sprOff', 'sprOn'):
+        k = agg[mode]
+        if not k['n']:
+            continue
+        sd = statistics.stdev(offs[mode]) if len(offs[mode]) > 1 else 0.0
+        print(f'{mode:8} {k["cap"]:4} {k["n"]:9} {k["miss"]:7} {k["extra"]:9} '
+              f'{k["dn"]:6} {k["dmiss"]:7} '
+              f'{k["lost"]:5}/{k["req"]:<5} '
+              f'{statistics.fmean(offs[mode]):6.2f} +-{sd:5.2f}')
+    n = sum(agg[m]['n'] for m in agg)
+    miss = sum(agg[m]['miss'] for m in agg)
+    print(f'\n{n} CPU accesses: {miss} not predicted '
+          f'({100.0 * miss / n:.2f}%)')
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('repo')
+    ap.add_argument('--2013', dest='only13', action='store_true')
+    ap.add_argument('--2026', dest='only26', action='store_true')
+    ap.add_argument('--quantum', type=int, default=1,
+                    help='VDP cycles the request times are quantised to '
+                         '(0 = not quantised)')
+    ap.add_argument('--overwrite', action='store_true',
+                    help='a new request overwrites an unserved one, as openMSX '
+                         'assumes, instead of being lost')
+    args = ap.parse_args()
+    if not args.only26:
+        run2013(args.repo, not args.overwrite)
+    if not args.only13:
+        run2026(args.repo, not args.overwrite, args.quantum)
+
+
+if __name__ == '__main__':
+    main()

--- a/doc/internal/vdp-vram-timing/cpu-arbitration-model.py
+++ b/doc/internal/vdp-vram-timing/cpu-arbitration-model.py
@@ -56,13 +56,11 @@ import statistics
 import sys
 
 TICKS = 1368
-LEAD = 27                # cycles, from the rising edge of /CSx
+LEAD = 16                # the arbiter's lookahead, in memory cycles
+DEAD = 2                 # cycles after an access during which a new port
+                         # access is still lost
 PAIR_EXTRA_LEAD = 2      # extra lead of a slot 6 cycles after another slot
-# The register frees this many cycles before the access, not at the access
-# itself: fitted on the 2013 set, where 9 is the unique optimum (7-8 and 10-11
-# are each worse by a handful), and confirmed on the 2026 set, where it predicts
-# 314 lost requests in sprites-on mode against about 326 observed.
-FREE_BEFORE = [9]
+FREE_BEFORE = [-DEAD]
 PERIOD_2013 = 3060       # 39 * 72 + 252
 IN_PERIOD = 72
 BURST = 40
@@ -90,29 +88,24 @@ PAIR = {m: {s for s in TABLES[m] if (s - 6) in set(TABLES[m])} for m in TABLES}
 # --------------------------------------------------------------------------
 def V(mode, t):
     """Memory-cycle time: real time minus the blanking stretch seen so far."""
-    line, c = divmod(int(t) if t == int(t) else t // 1, TICKS)
-    line, c = divmod(t, TICKS)
-    a, b = C.STRETCH[mode]
-    return t - (4 * line + (0 if c < a else 2 if c < b else 4))
-
-
-# How many of the 4 stretch cycles per line the CPU's lead absorbs.  The
-# command engine's delays absorb all 4; the CPU's lead absorbs 1, 2 or 3 (each
-# fits the 2013 set exactly, 0 and 4 do not).
-CPU_STRETCH = [2]
+    return C.V(mode, t)
 
 
 def decision(mode, s):
-    """Real time at which slot s is handed out."""
+    """Real time at which slot s is handed out.
+
+    The lookahead is counted in the VDP's memory cycles, exactly as the command
+    engine's delays are: the cycles the VDP pads the line with in the blanking
+    region do not count towards it.
+    """
     lead = LEAD + (PAIR_EXTRA_LEAD if (s % TICKS) in PAIR[mode] else 0)
-    base = s - lead
     want = V(mode, s) - lead
-    t = base
+    t = s - lead
     while V(mode, t) > want:
         t -= 1
     while V(mode, t + 1) <= want:
         t += 1
-    return base - ((base - t) * CPU_STRETCH[0]) // 4
+    return t
 
 
 def slots(mode, lo, hi):
@@ -344,11 +337,17 @@ def fit_pace(req):
     # two /CSx edges a few cycles apart cannot both be port accesses
     req = [r for i, r in enumerate(req) if i == 0 or r - req[i - 1] > 40]
     g = [b - a for a, b in zip(req, req[1:])]
-    s0 = statistics.median([x for x in g if 60 < x < 85]) / 12
+    # Two test programs: 40 x IN/OUT 12 T-states apart with 42 T-states from
+    # one burst to the next, and 20 x IN 37 T-states apart with 67 between
+    # bursts ('rdCpu222').
+    inner = statistics.median(x for x in g if x < 300)
+    step, tail = ((12, 42) if inner < 150 else (37, 67))
+    s0 = inner / step
     x = [0]
     for gap in g:
-        x.append(x[-1] + (42 if 240 < gap < 262
-                          else 12 * max(1, round(gap / (12 * s0)))))
+        n = round(gap / (step * s0))
+        x.append(x[-1] + (tail if abs(gap - tail * s0) < 20 * s0 / step
+                          else step * max(1, n)))
     keep = list(range(len(req)))
     s, phi, rms = s0, 0.0, 0.0
     for _ in range(4):
@@ -400,9 +399,12 @@ def run2026(repo, drop=True, quantum=1):
         rmss.append(rms)
         base = [phi + s * a for a in xs]
         lo, hi = obs[0] - 100, obs[-1] + 100
+        # the constant delay between the port access and the arbiter, fitted
+        # per capture: it also absorbs the residual alignment of the capture's
+        # own time base
         best = None
-        o = -6.0
-        while o < 6.0:
+        o = -8.0
+        while o < 24.0:
             # the VDP can only see a request at one of its own clock edges
             rq = [(quantum * math.ceil((b + o) / quantum) if quantum
                    else b + o) for b in base if lo - 150 < b + o < hi]
@@ -415,7 +417,8 @@ def run2026(repo, drop=True, quantum=1):
                 best = (score, o, ps, pds, lost, len(rq))
             o += 0.05
         _, off, ps, pds, lost, nreq = best
-        k = agg[mode]
+        pace = '222' if 'Cpu222' in name else ' 72'
+        k = agg[(pace, mode)]
         k['n'] += len(obs)
         k['miss'] += len(set(obs) - ps)
         k['extra'] += len(ps - set(obs))
@@ -425,25 +428,27 @@ def run2026(repo, drop=True, quantum=1):
         k['lost'] += lost
         k['req'] += nreq
         k['cap'] += 1
-        offs[mode].append(off)
+        offs[(pace, mode)].append(off)
     print(f'pace: {statistics.fmean(rates):.5f} +- {statistics.stdev(rates):.5f}'
           f' VDP cycles per Z80 T-state ({12 * statistics.fmean(rates):.4f} '
           f'cycles between port accesses; 6 and 72 on a single-clock machine), '
           f'fit residual {statistics.median(rmss):.3f} cycles')
     print(f'requests quantised to {quantum} VDP cycle(s)'
           if quantum else 'requests not quantised')
-    print(f'{"mode":8} {"cap":>4} {"accesses":>9} {"missed":>7} '
+    print(f'{"pace":4} {"mode":8} {"cap":>4} {"accesses":>9} {"missed":>7} '
           f'{"spurious":>9} {"dummy":>6} {"d-miss":>7} {"lost/req":>10} '
           f'{"offset":>13}')
-    for mode in ('dispOff', 'sprOff', 'sprOn'):
-        k = agg[mode]
-        if not k['n']:
-            continue
-        sd = statistics.stdev(offs[mode]) if len(offs[mode]) > 1 else 0.0
-        print(f'{mode:8} {k["cap"]:4} {k["n"]:9} {k["miss"]:7} {k["extra"]:9} '
-              f'{k["dn"]:6} {k["dmiss"]:7} '
-              f'{k["lost"]:5}/{k["req"]:<5} '
-              f'{statistics.fmean(offs[mode]):6.2f} +-{sd:5.2f}')
+    for pace in (' 72', '222'):
+        for mode in ('dispOff', 'sprOff', 'sprOn'):
+            k = agg[(pace, mode)]
+            if not k['n']:
+                continue
+            o = offs[(pace, mode)]
+            sd = statistics.stdev(o) if len(o) > 1 else 0.0
+            print(f'{pace:4} {mode:8} {k["cap"]:4} {k["n"]:9} {k["miss"]:7} '
+                  f'{k["extra"]:9} {k["dn"]:6} {k["dmiss"]:7} '
+                  f'{k["lost"]:5}/{k["req"]:<5} '
+                  f'{statistics.fmean(o):6.2f} +-{sd:5.2f}')
     n = sum(agg[m]['n'] for m in agg)
     miss = sum(agg[m]['miss'] for m in agg)
     print(f'\n{n} CPU accesses: {miss} not predicted '

--- a/doc/internal/vdp-vram-timing/vcd-slot-grid.py
+++ b/doc/internal/vdp-vram-timing/vcd-slot-grid.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Measure the VDP's VRAM access-slot grid from the raw logic-analyzer captures.
+
+Usage:
+    vcd-slot-grid.py <measurement-repo>/part2 [mode] [max-captures]
+
+The published analysis in the measurement repository derives access times by
+interpolating between the eight DRAM refresh accesses of a line.  This script
+does not need that: /RAS pulses once per potential access slot whether or not
+the VDP uses the slot, and its pattern repeats every display line, so the RAS
+edges themselves are a time base with ~166 anchors per line instead of 8.
+
+  1. Line period: exactly one gap per line is larger than all the others, so
+     the sample distance between successive occurrences of that gap is the line
+     period.  Fitted over the whole capture.
+  2. Numbering: the refresh accesses are 128 cycles apart with the row address
+     incrementing by one, and between the last of one line and the first of the
+     next there are 472 cycles, so the chain has a unique start.  That one sits
+     at cycle 284 in openMSX's numbering -- the slot openMSX omits between 276
+     and 292.
+  3. Each slot is then averaged over every line of every capture.  Sampling
+     jitter is +-1 sample = +-0.27 cycles per edge, so a few hundred edges put
+     the mean well inside a tenth of a cycle.
+
+Cycle numbers printed are openMSX's, which are based on /RAS.  The .txt files
+in the measurement repository are based on /CAS and are one higher.
+"""
+from __future__ import annotations
+
+import collections
+import glob
+import os
+import statistics
+import sys
+
+TICKS = 1368
+SAMPLE = 125          # 100 ps units per sample at a nominal 80 MHz
+REFRESH_CYCLE = 284   # openMSX numbering
+SIGNALS = {'!': 'A0', '"': 'A1', '#': 'A2', '$': 'A3', '%': 'A4', '&': 'A5',
+           "'": 'A6', '(': 'A7', ')': 'RAS', '*': 'CAS0', '+': 'CAS1',
+           ',': 'RW', '-': 'VDS', '.': 'IRQ', '/': 'CSW', '0': 'CSR'}
+
+# src/video/VDPAccessSlots.cc
+OPENMSX = {
+    'dispOff': [
+           0,    8,   16,   24,   32,   40,   48,   56,   64,   72,
+          80,   88,   96,  104,  112,  120,  164,  172,  180,  188,
+         196,  204,  212,  220,  228,  236,  244,  252,  260,  268,
+         276,  292,  300,  308,  316,  324,  332,  340,  348,  356,
+         364,  372,  380,  388,  396,  404,  420,  428,  436,  444,
+         452,  460,  468,  476,  484,  492,  500,  508,  516,  524,
+         532,  548,  556,  564,  572,  580,  588,  596,  604,  612,
+         620,  628,  636,  644,  652,  660,  676,  684,  692,  700,
+         708,  716,  724,  732,  740,  748,  756,  764,  772,  780,
+         788,  804,  812,  820,  828,  836,  844,  852,  860,  868,
+         876,  884,  892,  900,  908,  916,  932,  940,  948,  956,
+         964,  972,  980,  988,  996, 1004, 1012, 1020, 1028, 1036,
+        1044, 1060, 1068, 1076, 1084, 1092, 1100, 1108, 1116, 1124,
+        1132, 1140, 1148, 1156, 1164, 1172, 1188, 1196, 1204, 1212,
+        1220, 1228, 1268, 1276, 1284, 1292, 1300, 1308, 1316, 1324,
+        1334, 1344, 1352, 1360],
+    'sprOff': [
+           6,   14,   22,   30,   38,   46,   54,   62,   70,   78,
+          86,   94,  102,  110,  118,  162,  170,  182,  188,  214,
+         220,  246,  252,  278,  310,  316,  342,  348,  374,  380,
+         406,  438,  444,  470,  476,  502,  508,  534,  566,  572,
+         598,  604,  630,  636,  662,  694,  700,  726,  732,  758,
+         764,  790,  822,  828,  854,  860,  886,  892,  918,  950,
+         956,  982,  988, 1014, 1020, 1046, 1078, 1084, 1110, 1116,
+        1142, 1148, 1174, 1206, 1212, 1266, 1274, 1282, 1290, 1298,
+        1306, 1314, 1322, 1332, 1342, 1350, 1358, 1366],
+    'sprOn': [
+          28,   92,  162,  170,  188,  220,  252,  316,  348,  380,
+         444,  476,  508,  572,  604,  636,  700,  732,  764,  828,
+         860,  892,  956,  988, 1020, 1084, 1116, 1148, 1212, 1264,
+        1330],
+}
+
+
+# --------------------------------------------------------------------------
+# .vcd decoding
+# --------------------------------------------------------------------------
+def parse_vcd(path):
+    state = {n: None for n in SIGNALS.values()}
+    out = []
+    body = False
+    with open(path) as f:
+        for ln in f:
+            ln = ln.strip()
+            if not body:
+                body = ln == '$enddefinitions $end'
+                continue
+            if not ln.startswith('#'):
+                continue
+            parts = ln.split()
+            for p in parts[1:]:
+                state[SIGNALS[p[1:]]] = int(p[0])
+            out.append((int(parts[0][1:]) // SAMPLE, dict(state)))
+    return out
+
+
+def ras_edges(trace):
+    out, prev = [], None
+    for t, s in trace:
+        if prev == 1 and s['RAS'] == 0:
+            out.append(t)
+        prev = s['RAS']
+    return out
+
+
+def accesses(trace):
+    """(cas_sample, ras_sample, address, is_read) per VRAM access.
+
+    Row address on A7..A0 at the falling /RAS, column address at the falling
+    /CAS0 or /CAS1; which of the two also selects the 64kB bank.
+    """
+    out = []
+    ras_t = row = None
+    prev = {'RAS': None, 'CAS0': None, 'CAS1': None}
+    for t, s in trace:
+        if prev['RAS'] == 1 and s['RAS'] == 0:
+            ras_t, row = t, sum(s[f'A{i}'] << i for i in range(8))
+        for bank, cas in ((0, 'CAS0'), (1, 'CAS1')):
+            if prev[cas] == 1 and s[cas] == 0 and row is not None:
+                col = sum(s[f'A{i}'] << i for i in range(8))
+                out.append((t, ras_t, (bank << 16) | (row << 8) | col,
+                            s['RW'] == 1))
+        for k in prev:
+            prev[k] = s[k]
+    return out
+
+
+# --------------------------------------------------------------------------
+# grid fit
+# --------------------------------------------------------------------------
+def geometry(edges):
+    """(line period in samples, marks) from the unique largest gap per line."""
+    gaps = [b - a for a, b in zip(edges, edges[1:])]
+    if not gaps:
+        return None
+    mx = max(gaps)
+    marks = [i + 1 for i, g in enumerate(gaps) if g > mx * 0.9]
+    if len(marks) < 3:
+        return None
+    return (edges[marks[-1]] - edges[marks[0]]) / (len(marks) - 1), marks
+
+
+def refresh_chain_start(acc, cyc):
+    """RAS sample of the first refresh access of a line, or None.
+
+    Refresh accesses are 128 cycles apart with the row address incrementing by
+    one and the bank alternating; the gap before the first of a line is 472.
+    """
+    ts = sorted(acc, key=lambda a: a[1])
+    ref = set()
+    for i, a in enumerate(ts):
+        for b in ts[i + 1:]:
+            d = (b[1] - a[1]) * cyc
+            if d > 131:
+                break
+            if abs(d - 128) < 2.5 and \
+               ((b[2] >> 8) & 0xFF) == (((a[2] >> 8) & 0xFF) + 1) & 0xFF and \
+               (b[2] >> 16) != (a[2] >> 16):
+                ref.add(a[1])
+                ref.add(b[1])
+    r = sorted(ref)
+    starts = [t for i, t in enumerate(r)
+              if i and (t - r[i - 1]) * cyc > 200]
+    return (starts[0], ref) if starts else (None, ref)
+
+
+def measure(vcd_dir, mode, limit=None):
+    paths = sorted(glob.glob(os.path.join(vcd_dir, f'scr5-{mode}-*.vcd')))
+    if limit:
+        paths = paths[:limit]
+    hist, periods, used = [], [], 0
+    for p in paths:
+        trace = parse_vcd(p)
+        edges = ras_edges(trace)
+        g = geometry(edges)
+        if g is None:
+            continue
+        period, _ = g
+        cyc = TICKS / period
+        anchor, _ = refresh_chain_start(accesses(trace), cyc)
+        if anchor is None:
+            continue
+        periods.append(period)
+        used += 1
+        hist.extend(((e - anchor) * cyc + REFRESH_CYCLE) % TICKS for e in edges)
+    if not used:
+        return None
+    return hist, used, len(paths), statistics.fmean(periods)
+
+
+def slots_near(hist, target, window=2.0):
+    """Mean position of the RAS edges near 'target', unwrapped around it."""
+    v = []
+    for x in hist:
+        d = ((x - target + TICKS / 2) % TICKS) - TICKS / 2
+        if abs(d) < window:
+            v.append(target + d)
+    if not v:
+        return None
+    return statistics.fmean(v), (statistics.stdev(v) if len(v) > 1 else 0.0), len(v)
+
+
+def cluster(hist, width=3.0):
+    hist = sorted(hist)
+    groups, cur = [], [hist[0]]
+    for x in hist[1:]:
+        if x - cur[-1] < width:
+            cur.append(x)
+        else:
+            groups.append(cur)
+            cur = [x]
+    groups.append(cur)
+    if groups[0][0] + TICKS - groups[-1][-1] < width:
+        groups[0] = [x - TICKS for x in groups.pop()] + groups[0]
+    return sorted((statistics.fmean(g) % TICKS, len(g)) for g in groups)
+
+
+# --------------------------------------------------------------------------
+def check_published(txt_dir, mode, hist, tol=0.5):
+    """How many published access positions do not sit on a measured slot?
+
+    A position is accepted when the mean of the RAS edges around it is within
+    'tol' cycles of it; being one cycle off is a mismatch.
+    """
+    on_grid = {}
+
+    def ok(c):
+        if c not in on_grid:
+            m = slots_near(hist, c, window=2.5)
+            on_grid[c] = m is not None and abs(m[0] - c) <= tol
+        return on_grid[c]
+
+    bad, tot = collections.Counter(), 0
+    for path in sorted(glob.glob(os.path.join(txt_dir, f'scr5-{mode}-*.txt'))):
+        with open(path) as f:
+            for ln in f:
+                if ':' not in ln:
+                    continue
+                t = int(ln[:ln.index(':')])
+                rest = ln[ln.index(':') + 1:]
+                col = 0
+                while rest:
+                    if rest[2:13].strip():
+                        tot += 1
+                        c = (TICKS * col + t - 1) % TICKS   # CAS -> RAS
+                        if not ok(c):
+                            bad[c] += 1
+                    rest = rest[13:]
+                    col += 1
+    return tot, bad
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit(__doc__)
+    part2 = sys.argv[1]
+    modes = [sys.argv[2]] if len(sys.argv) > 2 else ['dispOff', 'sprOff', 'sprOn']
+    limit = int(sys.argv[3]) if len(sys.argv) > 3 else 40
+    for mode in modes:
+        r = measure(os.path.join(part2, '1.vcd'), mode, limit)
+        if r is None:
+            print(f'{mode}: no usable captures')
+            continue
+        hist, used, tot, period = r
+        print(f'=== {mode}: {used}/{tot} captures, line period {period:.3f} '
+              f'samples, {len(hist)} RAS edges ===')
+        cl = cluster(hist)
+        med = statistics.median([n for _, n in cl])
+        cl = [c for c in cl if c[1] > med * 0.15]
+        pos = [round(c[0]) % TICKS for c in cl]
+        gaps = collections.Counter((pos[(i + 1) % len(pos)] - p) % TICKS
+                                  for i, p in enumerate(pos))
+        print(f'  {len(pos)} slots per line; gaps ' +
+              ' '.join(f'{k}x{v}' for k, v in sorted(gaps.items())) +
+              f'  (sum {sum(k * v for k, v in gaps.items())})')
+        # every openMSX slot, checked individually
+        worst = (0, None)
+        for s in OPENMSX[mode]:
+            m = slots_near(hist, s)
+            if m is None:
+                print(f'  !! openMSX slot {s} has no RAS edge within 2 cycles')
+                continue
+            d = abs(m[0] - s)
+            if d > worst[0]:
+                worst = (d, (s, m))
+        print(f'  all {len(OPENMSX[mode])} openMSX slots confirmed; worst '
+              f'deviation {worst[0]:.3f} cycles'
+              + (f' (slot {worst[1][0]}: measured {worst[1][1][0]:.3f}, '
+                 f'sd {worst[1][1][1]:.2f}, n {worst[1][1][2]})'
+                 if worst[1] else ''))
+        n, bad = check_published(os.path.join(part2, '5.slots'), mode, hist)
+        nb = sum(bad.values())
+        print(f'  published .txt accesses off the measured grid: {nb} of {n} '
+              f'({100.0 * nb / max(n, 1):.2f}%)')
+        for c, k in bad.most_common(6):
+            print(f'     RAS {c} (CAS {c + 1}) x{k}')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/video/VDPAccessSlots.cc
+++ b/src/video/VDPAccessSlots.cc
@@ -160,29 +160,34 @@ protected:
   * documented here:
   *     https://github.com/sndpl/openMSX/pull/5
   *
-  * 'stretch1' / 'stretch2': 2 of the VDP's memory cycles are 10 cycles long
-  * where all the others in that part of the line are 8. The access slots in the
-  * horizontal blanking region are 10 apart there, and the /CAS of those two
-  * slots follows their /RAS by 2 cycles instead of 1. The command engine's
-  * delay counter does not see those 4 cycles, so a delay that spans them takes
-  * 4 more real cycles to be satisfied. The two values are the slots at which
-  * each stretch has completed, i.e. an interval (from, to] costs 2 cycles less
-  * per stretch it contains. 0 means 'not applicable to this table'.
+  * 'stretch' / 'step': the VDP pads its line out to 1368 cycles by making a few
+  * of its memory cycles in the horizontal blanking region longer than the rest.
+  * With the display off and with sprites off there are two such cycles, 10
+  * cycles long where the rest of that part of the line runs at 8 (and the /CAS
+  * of those two follows their /RAS by 2 cycles instead of 1); with sprites on
+  * there are three, each one cycle longer than the 13/6/10 pattern that part of
+  * the line otherwise has. The command engine's delay counter does not see
+  * those padding cycles, so a delay that spans them takes that many more real
+  * cycles to be satisfied. 'stretch' holds the cycle at which each of them has
+  * completed -- an interval (from, to] costs 'step' cycles less per entry it
+  * contains -- and 0 means 'no more'.
   * The underlying reason for this mechanism are the S1/S0 bits in R#9. With these
   * the VDP switches between 1368 and 1365 cycles per line (this is not emulated).
   * And then in 1368-mode, parts of the VDP 'stall' including the command engine
-  * part.
+  * part. Measured directly: with S1,S0 != 0,0 the line is 1365 cycles and those
+  * memory cycles have their ordinary length.
   *
-  * 'extra': added to every command engine step. Sprite rendering costs one
-  * extra cycle, as if the arbitration decision for a slot were taken one cycle
-  * earlier while the sprite fetch logic is active. (In earlier versions we
-  * emulated this with 'sprOn' specific values timing values in LMMM and HMMM).
+  * 'extra': added to every command engine step. Sprite rendering costs two
+  * extra cycles, as if the arbitration decision for a slot were taken two
+  * cycles earlier while the sprite fetch logic is active. (In earlier versions
+  * we emulated this with 'sprOn' specific values timing values in LMMM and
+  * HMMM). The CPU arbitration seems to pay a similar cost.
   *
-  * Both only apply to the V99x8 bitmap tables; the character, text and MSX1
-  * tables have never been measured this way and are left alone. */
+  * All of them only apply to the V99x8 bitmap tables; the character, text and
+  * MSX1 tables have never been measured this way and are left alone. */
 struct Timing {
-	int stretch1 = 0;
-	int stretch2 = 0;
+	std::array<int16_t, 3> stretch = {};
+	int step = 0;
 	int extra = 0;
 };
 
@@ -201,8 +206,9 @@ struct CycleTable : AccessTable
 		// Distance from cycle 'i' to slot 's' as the command engine counts it.
 		auto dist = [&](int i, int s) {
 			int d = s - i;
-			if ((i < timing.stretch1) && (timing.stretch1 <= s)) d -= 2;
-			if ((i < timing.stretch2) && (timing.stretch2 <= s)) d -= 2;
+			for (auto a : timing.stretch) {
+				if (a && (i < a) && (a <= s)) d -= timing.step;
+			}
 			return d;
 		};
 
@@ -269,11 +275,11 @@ struct ZeroTable : AccessTable
 {
 };
 
-static constexpr CycleTable tabSpritesOn    {false, slotsSpritesOn,  Timing{.stretch1 = 1332, .stretch2 = 1342, .extra = 1}};
-static constexpr CycleTable tabSpritesOff   {false, slotsSpritesOff, Timing{.stretch1 = 1332, .stretch2 = 1342, .extra = 0}};
+static constexpr CycleTable tabSpritesOn    {false, slotsSpritesOn,  Timing{.stretch = {1330, 1337, 1348}, .step = 1, .extra = 2}};
+static constexpr CycleTable tabSpritesOff   {false, slotsSpritesOff, Timing{.stretch = {1332, 1342}, .step = 2, .extra = 0}};
 static constexpr CycleTable tabChar         {false, slotsChar};
 static constexpr CycleTable tabText         {false, slotsText};
-static constexpr CycleTable tabScreenOff    {false, slotsScreenOff,  Timing{.stretch1 = 1334, .stretch2 = 1344, .extra = 0}};
+static constexpr CycleTable tabScreenOff    {false, slotsScreenOff,  Timing{.stretch = {1334, 1344}, .step = 2, .extra = 0}};
 static constexpr CycleTable tabMsx1Gfx12    {true,  slotsMsx1Gfx12};
 static constexpr CycleTable tabMsx1Gfx3     {true,  slotsMsx1Gfx3};
 static constexpr CycleTable tabMsx1Text     {true,  slotsMsx1Text};


### PR DESCRIPTION
Based on current master. Replaces #8 (its code is already merged as `5b0327eaf`).

**`005b7875f` — a code change**, from the new captures in https://github.com/m9710797/vdp-timing-measurements (`part2/*e.*`):

The R#9 S1/S0 captures pin down the line length (1368.01 ± 0.04 with S1,S0 = 0,0, 1364.94 ± 0.10 otherwise) and show exactly which memory cycles carry the difference. So the padding the command engine's delay counter does not see can be read off per mode instead of assumed: two cycles of 10 with the display off and with sprites off, but **three cycles one cycle longer with sprites on** — +3, not +4.

With that right, the cost of sprite rendering to every command engine step is **two** cycles rather than one. Both variants reproduce every transition in both measurement sets; the direct measurement of the padding is what separates them. Only the sprites-on table changes, in 374 of its 21888 entries.

**`347960b2a` — the analysis and the scripts.** Take it or leave it; if openMSX would rather not carry this, say so and I will drop that commit and keep the material in #5.

* `vcd-slot-grid.py` — measures the access-slot grid from /RAS in the raw captures
* `2026-measurement-check.py` — fits the command engine's per-step delays
* `cpu-arbitration-model.py` — fits how the CPU gets its slots
* `2026-measurement-analysis.md` — what they show

Nothing in `doc/internal/` is built or run by openMSX. All three scripts take a checkout of the measurement repository as their argument.

Current state: the command engine model reproduces all 98470 engine transitions in the two sets; the CPU model reproduces 1141 of 1141 accesses in the 2013 set and 99.2% of the 14766 in the 2026 set, where the CPU clock is asynchronous to the VDP's.

Ongoing discussion: #5.